### PR TITLE
Add virtual environment directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ __pycache__/
 
 *.log
 *.pid
+
+# Virtual environment
+venv/
+env/
+ENV/
+.venv/


### PR DESCRIPTION
## Summary
- Updates the .gitignore file to exclude common virtual environment directories

## Changes

### .gitignore
- Added entries to ignore `venv/`, `env/`, `ENV/`, and `.venv/` directories
- Helps prevent committing virtual environment files to the repository

## Test plan
- Verified that virtual environment directories are now ignored by git
- No existing files affected by this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b326bb30-2ad5-46e5-84fc-8de8c768f510