### PR TITLE
Fix CORS error by adding production frontend origin

### DIFF
--- a/api_service.py
+++ b/api_service.py
@@ -115,6 +115,7 @@ origins = [
     "http://localhost:5000",
     "http://127.0.0.1:5000",
     "http://192.168.1.162:5000",  # Allow your frontend's origin
+    "https://cat-emails.netlify.app",  # Production frontend on Netlify
 ]
 
 app.add_middleware(


### PR DESCRIPTION
## Summary
- Resolves CORS error issues for the production frontend hosted on Netlify by adding its URL to allowed origins.

## Changes

### Backend
- Updated `origins` list in `api_service.py` to include `https://cat-emails.netlify.app`.
- This allows cross-origin requests from the production frontend, preventing CORS errors during API calls.

## Test plan
- [x] Verified that API requests originating from the Netlify production frontend are no longer blocked by CORS.
- [x] Tested local and other allowed origins to confirm existing functionality remains unaffected.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/28794fbc-2427-4dd7-a053-dbf1466c1642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved cross-origin errors by allowing requests from the production frontend domain, ensuring the Netlify-hosted app can communicate with the API without interruptions.
* **Chores**
  * Updated CORS configuration to include the production frontend origin, improving reliability for users accessing the app from the live site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->