### PR TITLE
Display Google OAuth status on Accounts page (Auth Method column)

### DIFF
--- a/api_service.py
+++ b/api_service.py
@@ -1553,6 +1553,8 @@ async def oauth_callback(
         # Create or update account with OAuth tokens
         account_service.get_or_create_account(
             email_address=email_address,
+            display_name=None,
+            app_password=None,
             auth_method='oauth',
             oauth_refresh_token=refresh_token,
         )
@@ -1852,7 +1854,8 @@ async def get_all_accounts(
                 password_length=len(account.app_password) if account.app_password else 0,
                 is_active=account.is_active,
                 last_scan_at=account.last_scan_at,
-                created_at=account.created_at
+                created_at=account.created_at,
+                auth_method=account.auth_method
             )
             for account in accounts
         ]

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -1284,3 +1284,71 @@ Features: 0/1 complete (feature_list.md - FEAT-001: User can process emails from
 
 Next: Invoking debugger agent for CRASH-RCA forensic analysis
 ---
+
+=== Session 20260106-222849 ===
+Workflow: architect
+Task: Add visual indicator on Accounts page showing Gmail OAuth connection status
+Status: Initialized
+Context: Explored project structure, identified OAuth and accounts components
+
+Tech Stack:
+- Language: Python 3.12
+- Framework: FastAPI for REST API (api_service.py - ~109k lines)
+- Database: SQLAlchemy with MySQL/SQLite support, Flyway for SQL migrations
+- Frontend: Jinja2 templates, Bootstrap, vanilla JavaScript
+- AI/ML: OpenAI SDK for LLM-based email categorization
+- Email: IMAP (imapclient) for Gmail integration, OAuth 2.0 support
+- Testing: pytest with BDD (Gherkin feature files in tests/bdd/)
+- Build: Docker with Tini entrypoint, Makefile
+
+Task Analysis:
+The user wants a visual indicator on the Accounts page showing whether each account uses OAuth or IMAP authentication:
+- Green "OAuth Connected" badge for OAuth accounts
+- Gray "IMAP" badge for IMAP credential accounts
+
+Key Files Identified:
+
+1. /root/repo/api_service.py (lines 1814-1864) - GET /api/accounts endpoint
+   - Currently returns: id, email_address, display_name, masked_password, password_length, is_active, last_scan_at, created_at
+   - MISSING: auth_method field
+   - Can access account.auth_method from EmailAccount model but doesn't include it in response
+
+2. /root/repo/api_service.py (lines 1596-1642) - GET /api/accounts/{email}/oauth-status endpoint
+   - Returns OAuthStatusResponse with: connected, auth_method, scopes, token_expiry
+   - This endpoint EXISTS but requires per-account API calls
+
+3. /root/repo/models/account_models.py (lines 97-133) - EmailAccountInfo response model
+   - Currently MISSING auth_method field
+   - Need to add: auth_method: str = Field(default='imap', description="Authentication method: 'imap' or 'oauth'")
+
+4. /root/repo/models/database.py (lines 31-60) - EmailAccount SQLAlchemy model
+   - Has auth_method column: auth_method = Column(String(20), default='imap')
+   - Database model is COMPLETE
+
+5. /root/repo/frontend/templates/accounts.html - Accounts page template
+   - Table columns: Email Address, Display Name, Status, Last Scan, Created, Actions
+   - Need to add new "Auth Method" column with badge styling
+   - renderAccountsTable() function builds table rows
+
+6. /root/repo/models/oauth_models.py (lines 42-57) - OAuthStatusResponse
+   - Already has auth_method field definition
+
+Implementation Plan:
+Option A (Recommended - Efficient): Add auth_method to /api/accounts response
+- Modify EmailAccountInfo to include auth_method field
+- Update GET /api/accounts to include account.auth_method in response
+- Update frontend to display badge based on auth_method value
+- Single API call, no N+1 queries
+
+Option B (Less efficient): Call /api/accounts/{email}/oauth-status per account
+- Frontend makes separate call for each account
+- N+1 API calls pattern - not recommended
+
+Features: 0/1 complete (feature_list.md - FEAT-001: User can process emails from Gmail via API)
+
+Active Task from architects_digest.md:
+1. Enhance Audit Records for Email Processing - ALL sub-tasks (1.1-1.7) COMPLETED
+   New task will be added for OAuth status indicator feature
+
+Next: Invoking architect agent to create spec for OAuth status visual indicator
+---

--- a/clients/account_category_client.py
+++ b/clients/account_category_client.py
@@ -137,10 +137,10 @@ class AccountCategoryClient(AccountCategoryClientInterface):
     def get_or_create_account(
         self,
         email_address: str,
-        display_name: Optional[str] = None,
-        app_password: Optional[str] = None,
-        auth_method: str = "imap",
-        oauth_refresh_token: Optional[str] = None,
+        display_name: Optional[str],
+        app_password: Optional[str],
+        auth_method: Optional[str],
+        oauth_refresh_token: Optional[str],
     ) -> EmailAccount:
         """
         Get existing account or create a new one.
@@ -182,8 +182,8 @@ class AccountCategoryClient(AccountCategoryClientInterface):
         email_address: str,
         display_name: Optional[str],
         app_password: Optional[str],
-        auth_method: str = "imap",
-        oauth_refresh_token: Optional[str] = None,
+        auth_method: Optional[str],
+        oauth_refresh_token: Optional[str],
     ) -> EmailAccount:
         """Implementation of get_or_create_account that works with a session."""
         try:
@@ -292,7 +292,7 @@ class AccountCategoryClient(AccountCategoryClientInterface):
         
         try:
             # Get or create account first
-            account = self.get_or_create_account(email_address)
+            account = self.get_or_create_account(email_address, None, None, None, None)
             
             if self.owns_session:
                 with self._get_session() as session:
@@ -334,7 +334,7 @@ class AccountCategoryClient(AccountCategoryClientInterface):
         
         try:
             # Get or create account
-            account = self.get_or_create_account(email_address)
+            account = self.get_or_create_account(email_address, None, None, None, None)
             
             if self.owns_session:
                 with self._get_session() as session:
@@ -530,7 +530,7 @@ class AccountCategoryClient(AccountCategoryClientInterface):
             logger.error(f"Unexpected error in _get_top_categories_impl: {str(e)}")
             raise
     
-    def get_all_accounts(self, active_only: bool = True) -> List[EmailAccount]:
+    def get_all_accounts(self, active_only: bool) -> List[EmailAccount]:
         """
         Get list of all tracked accounts.
         
@@ -803,7 +803,7 @@ if __name__ == "__main__":
     
     try:
         # Create/get an account
-        account = service.get_or_create_account("test@gmail.com", "Test User")
+        account = service.get_or_create_account("test@gmail.com", "Test User", None, None, None)
         print(f"Account created/retrieved: {account.email_address}")
         
         # Record some category stats

--- a/clients/account_category_client.py
+++ b/clients/account_category_client.py
@@ -803,7 +803,7 @@ if __name__ == "__main__":
     
     try:
         # Create/get an account
-        account = service.get_or_create_account("test@gmail.com", "Test User", None, None, None)
+        account = service.get_or_create_account("test@gmail.com", "Test User", None, None, None, None)
         print(f"Account created/retrieved: {account.email_address}")
         
         # Record some category stats

--- a/clients/account_category_client.py
+++ b/clients/account_category_client.py
@@ -803,7 +803,7 @@ if __name__ == "__main__":
     
     try:
         # Create/get an account
-        account = service.get_or_create_account("test@gmail.com", "Test User", None, None, None, None)
+        account = service.get_or_create_account("test@gmail.com", "Test User", None, None, None)
         print(f"Account created/retrieved: {account.email_address}")
         
         # Record some category stats

--- a/clients/account_category_client_interface.py
+++ b/clients/account_category_client_interface.py
@@ -14,7 +14,7 @@ class AccountCategoryClientInterface(ABC):
     """Interface for managing email accounts and category statistics."""
 
     @abstractmethod
-    def get_or_create_account(self, email_address: str, display_name: Optional[str], app_password: Optional[str], auth_method: Optional[str]) -> EmailAccount:
+    def get_or_create_account(self, email_address: str, display_name: Optional[str], app_password: Optional[str], auth_method: Optional[str], oauth_refresh_token: Optional[str]) -> EmailAccount:
         """
         Get existing account or create a new one.
 
@@ -23,6 +23,7 @@ class AccountCategoryClientInterface(ABC):
             display_name: Optional display name for the account
             app_password: Optional Gmail app-specific password for IMAP access
             auth_method: Optional authentication method ('oauth', 'imap', or None)
+            oauth_refresh_token: OAuth refresh token (required if auth_method is 'oauth')
 
         Returns:
             EmailAccount object (existing or newly created)

--- a/clients/account_category_client_interface.py
+++ b/clients/account_category_client_interface.py
@@ -14,13 +14,15 @@ class AccountCategoryClientInterface(ABC):
     """Interface for managing email accounts and category statistics."""
 
     @abstractmethod
-    def get_or_create_account(self, email_address: str, display_name: Optional[str] = None) -> EmailAccount:
+    def get_or_create_account(self, email_address: str, display_name: Optional[str], app_password: Optional[str], auth_method: Optional[str]) -> EmailAccount:
         """
         Get existing account or create a new one.
 
         Args:
             email_address: Gmail email address
             display_name: Optional display name for the account
+            app_password: Optional Gmail app-specific password for IMAP access
+            auth_method: Optional authentication method ('oauth', 'imap', or None)
 
         Returns:
             EmailAccount object (existing or newly created)
@@ -97,12 +99,12 @@ class AccountCategoryClientInterface(ABC):
         pass
 
     @abstractmethod
-    def get_all_accounts(self, active_only: bool = True) -> List[EmailAccount]:
+    def get_all_accounts(self, active_only: bool) -> List[EmailAccount]:
         """
         Get all accounts, optionally filtered by active status.
 
         Args:
-            active_only: If True, only return active accounts (default: True)
+            active_only: If True, only return active accounts
 
         Returns:
             List of EmailAccount objects

--- a/email_summaries/archives/tracked_20260106_233239.json
+++ b/email_summaries/archives/tracked_20260106_233239.json
@@ -5,7 +5,7 @@
     "subject": "Invoice Payment Due",
     "category": "WantsMoney",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.933431",
+    "processed_at": "2026-01-06 23:32:39.560208",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   },
@@ -15,7 +15,7 @@
     "subject": "Meeting Schedule Update",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.952362",
+    "processed_at": "2026-01-06 23:32:39.587385",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -25,7 +25,7 @@
     "subject": "Project Status Report",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.958922",
+    "processed_at": "2026-01-06 23:32:39.596183",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -35,7 +35,7 @@
     "subject": "Hello from your friend",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.965263",
+    "processed_at": "2026-01-06 23:32:39.603026",
     "sender_domain": "personal.com",
     "was_pre_categorized": false
   },
@@ -45,7 +45,7 @@
     "subject": "Subscription Renewal Notice",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.971989",
+    "processed_at": "2026-01-06 23:32:39.608823",
     "sender_domain": "subscriptions.com",
     "was_pre_categorized": false
   },
@@ -55,7 +55,7 @@
     "subject": "Order Confirmation",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.989180",
+    "processed_at": "2026-01-06 23:32:39.642905",
     "sender_domain": "ecommerce.com",
     "was_pre_categorized": false
   },
@@ -65,7 +65,7 @@
     "subject": "Account Statement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.006318",
+    "processed_at": "2026-01-06 23:32:39.662717",
     "sender_domain": "bank.com",
     "was_pre_categorized": false
   },
@@ -75,7 +75,7 @@
     "subject": "Team Announcement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.026069",
+    "processed_at": "2026-01-06 23:32:39.671136",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   }

--- a/email_summaries/archives/tracked_20260106_233240.json
+++ b/email_summaries/archives/tracked_20260106_233240.json
@@ -5,7 +5,7 @@
     "subject": "Invoice Payment Due",
     "category": "WantsMoney",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.933431",
+    "processed_at": "2026-01-06 23:32:40.490384",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   },
@@ -15,7 +15,7 @@
     "subject": "Meeting Schedule Update",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.952362",
+    "processed_at": "2026-01-06 23:32:40.508971",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -25,7 +25,7 @@
     "subject": "Project Status Report",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.958922",
+    "processed_at": "2026-01-06 23:32:40.516543",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -35,7 +35,7 @@
     "subject": "Hello from your friend",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.965263",
+    "processed_at": "2026-01-06 23:32:40.523277",
     "sender_domain": "personal.com",
     "was_pre_categorized": false
   },
@@ -45,7 +45,7 @@
     "subject": "Subscription Renewal Notice",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.971989",
+    "processed_at": "2026-01-06 23:32:40.530496",
     "sender_domain": "subscriptions.com",
     "was_pre_categorized": false
   },
@@ -55,7 +55,7 @@
     "subject": "Order Confirmation",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.989180",
+    "processed_at": "2026-01-06 23:32:40.546762",
     "sender_domain": "ecommerce.com",
     "was_pre_categorized": false
   },
@@ -65,7 +65,7 @@
     "subject": "Account Statement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.006318",
+    "processed_at": "2026-01-06 23:32:40.561040",
     "sender_domain": "bank.com",
     "was_pre_categorized": false
   },
@@ -75,7 +75,7 @@
     "subject": "Team Announcement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.026069",
+    "processed_at": "2026-01-06 23:32:40.567332",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   }

--- a/email_summaries/archives/tracked_20260106_233319.json
+++ b/email_summaries/archives/tracked_20260106_233319.json
@@ -5,7 +5,7 @@
     "subject": "Invoice Payment Due",
     "category": "WantsMoney",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.933431",
+    "processed_at": "2026-01-06 23:32:40.887648",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   },
@@ -15,7 +15,7 @@
     "subject": "Meeting Schedule Update",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.952362",
+    "processed_at": "2026-01-06 23:32:40.911987",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -25,7 +25,7 @@
     "subject": "Project Status Report",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.958922",
+    "processed_at": "2026-01-06 23:32:40.920348",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -35,7 +35,7 @@
     "subject": "Hello from your friend",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.965263",
+    "processed_at": "2026-01-06 23:32:40.928751",
     "sender_domain": "personal.com",
     "was_pre_categorized": false
   },
@@ -45,7 +45,7 @@
     "subject": "Subscription Renewal Notice",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.971989",
+    "processed_at": "2026-01-06 23:32:40.935652",
     "sender_domain": "subscriptions.com",
     "was_pre_categorized": false
   },
@@ -55,7 +55,7 @@
     "subject": "Order Confirmation",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.989180",
+    "processed_at": "2026-01-06 23:32:40.956886",
     "sender_domain": "ecommerce.com",
     "was_pre_categorized": false
   },
@@ -65,7 +65,7 @@
     "subject": "Account Statement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.006318",
+    "processed_at": "2026-01-06 23:32:40.975517",
     "sender_domain": "bank.com",
     "was_pre_categorized": false
   },
@@ -75,7 +75,7 @@
     "subject": "Team Announcement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.026069",
+    "processed_at": "2026-01-06 23:32:40.982805",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   }

--- a/email_summaries/archives/tracked_20260106_233327.json
+++ b/email_summaries/archives/tracked_20260106_233327.json
@@ -5,7 +5,7 @@
     "subject": "Invoice Payment Due",
     "category": "WantsMoney",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.933431",
+    "processed_at": "2026-01-06 23:33:27.269625",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   },
@@ -15,7 +15,7 @@
     "subject": "Meeting Schedule Update",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.952362",
+    "processed_at": "2026-01-06 23:33:27.295363",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -25,7 +25,7 @@
     "subject": "Project Status Report",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.958922",
+    "processed_at": "2026-01-06 23:33:27.302730",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -35,7 +35,7 @@
     "subject": "Hello from your friend",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.965263",
+    "processed_at": "2026-01-06 23:33:27.310050",
     "sender_domain": "personal.com",
     "was_pre_categorized": false
   },
@@ -45,7 +45,7 @@
     "subject": "Subscription Renewal Notice",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.971989",
+    "processed_at": "2026-01-06 23:33:27.316907",
     "sender_domain": "subscriptions.com",
     "was_pre_categorized": false
   },
@@ -55,7 +55,7 @@
     "subject": "Order Confirmation",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.989180",
+    "processed_at": "2026-01-06 23:33:27.334805",
     "sender_domain": "ecommerce.com",
     "was_pre_categorized": false
   },
@@ -65,7 +65,7 @@
     "subject": "Account Statement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.006318",
+    "processed_at": "2026-01-06 23:33:27.355769",
     "sender_domain": "bank.com",
     "was_pre_categorized": false
   },
@@ -75,7 +75,7 @@
     "subject": "Team Announcement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.026069",
+    "processed_at": "2026-01-06 23:33:27.363474",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   }

--- a/email_summaries/archives/tracked_20260106_233328.json
+++ b/email_summaries/archives/tracked_20260106_233328.json
@@ -5,7 +5,7 @@
     "subject": "Invoice Payment Due",
     "category": "WantsMoney",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.933431",
+    "processed_at": "2026-01-06 23:33:28.167813",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   },
@@ -15,7 +15,7 @@
     "subject": "Meeting Schedule Update",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.952362",
+    "processed_at": "2026-01-06 23:33:28.187964",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -25,7 +25,7 @@
     "subject": "Project Status Report",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.958922",
+    "processed_at": "2026-01-06 23:33:28.194904",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -35,7 +35,7 @@
     "subject": "Hello from your friend",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.965263",
+    "processed_at": "2026-01-06 23:33:28.203635",
     "sender_domain": "personal.com",
     "was_pre_categorized": false
   },
@@ -45,7 +45,7 @@
     "subject": "Subscription Renewal Notice",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.971989",
+    "processed_at": "2026-01-06 23:33:28.210178",
     "sender_domain": "subscriptions.com",
     "was_pre_categorized": false
   },
@@ -55,7 +55,7 @@
     "subject": "Order Confirmation",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.989180",
+    "processed_at": "2026-01-06 23:33:28.225849",
     "sender_domain": "ecommerce.com",
     "was_pre_categorized": false
   },
@@ -65,7 +65,7 @@
     "subject": "Account Statement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.006318",
+    "processed_at": "2026-01-06 23:33:28.242367",
     "sender_domain": "bank.com",
     "was_pre_categorized": false
   },
@@ -75,7 +75,7 @@
     "subject": "Team Announcement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.026069",
+    "processed_at": "2026-01-06 23:33:28.249184",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   }

--- a/email_summaries/archives/tracked_20260106_233442.json
+++ b/email_summaries/archives/tracked_20260106_233442.json
@@ -5,7 +5,7 @@
     "subject": "Invoice Payment Due",
     "category": "WantsMoney",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.933431",
+    "processed_at": "2026-01-06 23:33:28.522440",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   },
@@ -15,7 +15,7 @@
     "subject": "Meeting Schedule Update",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.952362",
+    "processed_at": "2026-01-06 23:33:28.543519",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -25,7 +25,7 @@
     "subject": "Project Status Report",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.958922",
+    "processed_at": "2026-01-06 23:33:28.553159",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -35,7 +35,7 @@
     "subject": "Hello from your friend",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.965263",
+    "processed_at": "2026-01-06 23:33:28.560955",
     "sender_domain": "personal.com",
     "was_pre_categorized": false
   },
@@ -45,7 +45,7 @@
     "subject": "Subscription Renewal Notice",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.971989",
+    "processed_at": "2026-01-06 23:33:28.568883",
     "sender_domain": "subscriptions.com",
     "was_pre_categorized": false
   },
@@ -55,7 +55,7 @@
     "subject": "Order Confirmation",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.989180",
+    "processed_at": "2026-01-06 23:33:28.587303",
     "sender_domain": "ecommerce.com",
     "was_pre_categorized": false
   },
@@ -65,7 +65,7 @@
     "subject": "Account Statement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.006318",
+    "processed_at": "2026-01-06 23:33:28.605538",
     "sender_domain": "bank.com",
     "was_pre_categorized": false
   },
@@ -75,7 +75,7 @@
     "subject": "Team Announcement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.026069",
+    "processed_at": "2026-01-06 23:33:28.612450",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   }

--- a/email_summaries/archives/tracked_20260106_233450.json
+++ b/email_summaries/archives/tracked_20260106_233450.json
@@ -5,7 +5,7 @@
     "subject": "Invoice Payment Due",
     "category": "WantsMoney",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.933431",
+    "processed_at": "2026-01-06 23:34:50.560867",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   },
@@ -15,7 +15,7 @@
     "subject": "Meeting Schedule Update",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.952362",
+    "processed_at": "2026-01-06 23:34:50.582396",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -25,7 +25,7 @@
     "subject": "Project Status Report",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.958922",
+    "processed_at": "2026-01-06 23:34:50.590507",
     "sender_domain": "workplace.com",
     "was_pre_categorized": false
   },
@@ -35,7 +35,7 @@
     "subject": "Hello from your friend",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.965263",
+    "processed_at": "2026-01-06 23:34:50.598933",
     "sender_domain": "personal.com",
     "was_pre_categorized": false
   },
@@ -45,7 +45,7 @@
     "subject": "Subscription Renewal Notice",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.971989",
+    "processed_at": "2026-01-06 23:34:50.607059",
     "sender_domain": "subscriptions.com",
     "was_pre_categorized": false
   },
@@ -55,7 +55,7 @@
     "subject": "Order Confirmation",
     "category": "Marketing",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:50.989180",
+    "processed_at": "2026-01-06 23:34:50.627521",
     "sender_domain": "ecommerce.com",
     "was_pre_categorized": false
   },
@@ -65,7 +65,7 @@
     "subject": "Account Statement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.006318",
+    "processed_at": "2026-01-06 23:34:50.645582",
     "sender_domain": "bank.com",
     "was_pre_categorized": false
   },
@@ -75,7 +75,7 @@
     "subject": "Team Announcement",
     "category": "Other",
     "action": "kept",
-    "processed_at": "2026-01-06 23:34:51.026069",
+    "processed_at": "2026-01-06 23:34:50.653249",
     "sender_domain": "company.com",
     "was_pre_categorized": false
   }

--- a/examples/fake_account_category_client_usage.py
+++ b/examples/fake_account_category_client_usage.py
@@ -15,8 +15,8 @@ def example_usage():
     client = FakeAccountCategoryClient()
 
     # Create some accounts
-    account1 = client.get_or_create_account("user1@example.com", "User One")
-    account2 = client.get_or_create_account("user2@example.com", "User Two")
+    account1 = client.get_or_create_account("user1@example.com", "User One", None, None)
+    account2 = client.get_or_create_account("user2@example.com", "User Two", None, None)
 
     print(f"Created account: {account1.email_address} (ID: {account1.id})")
     print(f"Created account: {account2.email_address} (ID: {account2.id})")

--- a/frontend/templates/accounts.html
+++ b/frontend/templates/accounts.html
@@ -86,6 +86,35 @@
         box-shadow: 0 2px 4px rgba(107, 114, 128, 0.3);
     }
 
+    /* Auth method badges */
+    .auth-badge {
+        padding: 0.375rem 0.75rem;
+        border-radius: 1rem;
+        font-size: 0.8125rem;
+        font-weight: 600;
+        display: inline-block;
+        min-width: 7rem;
+        text-align: center;
+    }
+
+    .auth-badge.oauth {
+        background-color: #198754;
+        color: white;
+        box-shadow: 0 2px 4px rgba(25, 135, 84, 0.3);
+    }
+
+    .auth-badge.imap {
+        background-color: #6c757d;
+        color: white;
+        box-shadow: 0 2px 4px rgba(108, 117, 125, 0.3);
+    }
+
+    .auth-badge.not-configured {
+        background-color: #f8f9fa;
+        color: #212529;
+        border: 1px solid #dee2e6;
+    }
+
     /* Action buttons */
     .action-buttons {
         display: flex;
@@ -333,6 +362,7 @@
             <thead>
                 <tr>
                     <th>Email Address</th>
+                    <th>Auth Method</th>
                     <th>Display Name</th>
                     <th>Status</th>
                     <th>Last Scan</th>
@@ -514,6 +544,30 @@
             emailSpan.textContent = account.email_address;
             emailCell.appendChild(emailSpan);
 
+            // Create Auth Method cell
+            const authMethodCell = document.createElement('td');
+            authMethodCell.setAttribute('data-label', 'Auth Method');
+            const authBadge = document.createElement('span');
+            authBadge.className = 'auth-badge';
+
+            // Determine badge text and style based on auth_method (case-insensitive)
+            const authMethod = account.auth_method ? account.auth_method.toLowerCase() : null;
+            if (authMethod === 'oauth') {
+                authBadge.classList.add('oauth');
+                authBadge.textContent = 'OAuth Connected';
+                authBadge.setAttribute('aria-label', 'Authentication method: OAuth Connected');
+            } else if (authMethod === 'imap') {
+                authBadge.classList.add('imap');
+                authBadge.textContent = 'IMAP';
+                authBadge.setAttribute('aria-label', 'Authentication method: IMAP');
+            } else {
+                authBadge.classList.add('not-configured');
+                authBadge.textContent = 'Not Configured';
+                authBadge.setAttribute('aria-label', 'Authentication method: Not Configured');
+            }
+
+            authMethodCell.appendChild(authBadge);
+
             // Create Display Name cell
             const displayNameCell = document.createElement('td');
             displayNameCell.setAttribute('data-label', 'Display Name');
@@ -587,6 +641,7 @@
 
             // Append all cells to row
             row.appendChild(emailCell);
+            row.appendChild(authMethodCell);
             row.appendChild(displayNameCell);
             row.appendChild(statusCell);
             row.appendChild(lastScanCell);

--- a/gmail_fetcher.py
+++ b/gmail_fetcher.py
@@ -153,7 +153,7 @@ class GmailFetcher:
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
+            self.account_service.get_or_create_account(self.email_address, None, None, None, None, None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/gmail_fetcher.py
+++ b/gmail_fetcher.py
@@ -153,7 +153,7 @@ class GmailFetcher:
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address, None, None, None, None, None)
+            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/gmail_fetcher.py
+++ b/gmail_fetcher.py
@@ -153,7 +153,7 @@ class GmailFetcher:
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address)
+            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/gmail_fetcher.py
+++ b/gmail_fetcher.py
@@ -153,7 +153,8 @@ class GmailFetcher:
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
+            # Mark as IMAP authentication with the app password
+            self.account_service.get_or_create_account(self.email_address, None, app_password, 'imap', None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/models/account_models.py
+++ b/models/account_models.py
@@ -120,6 +120,10 @@ class EmailAccountInfo(BaseModel):
         description="Timestamp of the last successful email scan"
     )
     created_at: datetime = Field(description="When the account was first added to tracking")
+    auth_method: Optional[str] = Field(
+        None,
+        description="Authentication method: 'oauth', 'imap', or null for legacy accounts"
+    )
 
 
 class AccountListResponse(BaseModel):

--- a/prompts/completed/001-bdd-oauth-status-badge.md
+++ b/prompts/completed/001-bdd-oauth-status-badge.md
@@ -1,0 +1,273 @@
+---
+executor: bdd
+source_feature: ./tests/bdd/oauth-status-badge.feature
+---
+
+<objective>
+Implement the OAuth Status Badge feature on the Accounts page as defined by the BDD scenarios below.
+The implementation must make all 17 Gherkin scenarios pass, displaying authentication method badges
+(green "OAuth Connected", gray "IMAP", or neutral "Not Configured") for each email account in the
+accounts table.
+</objective>
+
+<gherkin>
+Feature: OAuth Status Badge on Accounts Page
+  As a user of the email management system
+  I want to see the authentication method for each account on the Accounts page
+  So that I can quickly identify which accounts use OAuth and which use IMAP
+
+  Background:
+    Given the Accounts page is loaded
+    And the accounts list is retrieved from the system
+
+  # === HAPPY PATHS ===
+
+  Scenario: OAuth Connected account displays green badge
+    Given an account "user@gmail.com" has auth_method "oauth"
+    When the accounts table is displayed
+    Then the account "user@gmail.com" should show a green "OAuth Connected" badge
+
+  Scenario: IMAP account displays gray badge
+    Given an account "user@company.com" has auth_method "imap"
+    When the accounts table is displayed
+    Then the account "user@company.com" should show a gray "IMAP" badge
+
+  Scenario: Accounts list shows mixed authentication methods
+    Given the following accounts exist:
+      | email               | auth_method |
+      | oauth1@gmail.com    | oauth       |
+      | imap1@company.com   | imap        |
+      | oauth2@gmail.com    | oauth       |
+    When the accounts table is displayed
+    Then "oauth1@gmail.com" should show a green "OAuth Connected" badge
+    And "imap1@company.com" should show a gray "IMAP" badge
+    And "oauth2@gmail.com" should show a green "OAuth Connected" badge
+
+  Scenario: Auth Method column is visible in accounts table
+    Given accounts exist in the system
+    When the accounts table is displayed
+    Then the table should have an "Auth Method" column header
+    And the "Auth Method" column should appear after the "Email" column
+
+  # === EDGE CASES ===
+
+  Scenario: Legacy account with null auth_method displays Not Configured badge
+    Given an account "legacy@gmail.com" has auth_method null
+    When the accounts table is displayed
+    Then the account "legacy@gmail.com" should show a neutral "Not Configured" badge
+
+  Scenario: Empty accounts list renders correctly
+    Given no accounts exist in the system
+    When the accounts table is displayed
+    Then the table should render with headers but no data rows
+    And the "Auth Method" column header should still be visible
+
+  Scenario: Case insensitive auth_method handling
+    Given an account "user@gmail.com" has auth_method "OAuth"
+    When the accounts table is displayed
+    Then the account "user@gmail.com" should show a green "OAuth Connected" badge
+
+  # === API RESPONSE BEHAVIOR ===
+
+  Scenario: API response includes auth_method for each account
+    Given accounts exist with various authentication methods
+    When the system retrieves the accounts list
+    Then each account in the response should include an auth_method field
+
+  Scenario: OAuth account returns oauth auth_method in API response
+    Given an account "user@gmail.com" is configured with OAuth
+    When the system retrieves the accounts list
+    Then the response for "user@gmail.com" should have auth_method "oauth"
+
+  Scenario: IMAP account returns imap auth_method in API response
+    Given an account "user@company.com" is configured with IMAP credentials
+    When the system retrieves the accounts list
+    Then the response for "user@company.com" should have auth_method "imap"
+
+  Scenario: Legacy account returns null auth_method in API response
+    Given an account "legacy@gmail.com" was created before auth_method tracking
+    When the system retrieves the accounts list
+    Then the response for "legacy@gmail.com" should have auth_method null
+
+  # === ERROR HANDLING ===
+
+  Scenario: Badge renders gracefully for unexpected auth_method value
+    Given an account "user@gmail.com" has auth_method "unexpected_value"
+    When the accounts table is displayed
+    Then the account "user@gmail.com" should show a neutral "Not Configured" badge
+
+  Scenario: Badge renders when auth_method field is missing from response
+    Given an account response is missing the auth_method field
+    When the accounts table is displayed
+    Then the account should show a neutral "Not Configured" badge
+
+  # === ACCESSIBILITY ===
+
+  Scenario: OAuth badge has accessible aria-label
+    Given an account "user@gmail.com" has auth_method "oauth"
+    When the accounts table is displayed
+    Then the badge for "user@gmail.com" should have aria-label "Authentication method: OAuth Connected"
+
+  Scenario: IMAP badge has accessible aria-label
+    Given an account "user@company.com" has auth_method "imap"
+    When the accounts table is displayed
+    Then the badge for "user@company.com" should have aria-label "Authentication method: IMAP"
+
+  Scenario: Not Configured badge has accessible aria-label
+    Given an account "legacy@gmail.com" has auth_method null
+    When the accounts table is displayed
+    Then the badge for "legacy@gmail.com" should have aria-label "Authentication method: Not Configured"
+
+  Scenario: Auth Method column header is accessible
+    Given accounts exist in the system
+    When the accounts table is displayed
+    Then the "Auth Method" column header should have appropriate table header scope
+</gherkin>
+
+<requirements>
+Based on the Gherkin scenarios, implement the following:
+
+## Backend Requirements
+
+1. **Update EmailAccountInfo model** (`models/account_models.py`)
+   - Add `auth_method: Optional[str]` field to the Pydantic model
+   - Field should accept "oauth", "imap", or null values
+   - Include appropriate Field description
+
+2. **Update GET /api/accounts endpoint** (`api_service.py`)
+   - Include `auth_method` in the EmailAccountInfo mapping
+   - Map directly from `account.auth_method` database value
+   - Handle null values gracefully (legacy accounts)
+
+## Frontend Requirements
+
+3. **Add Auth Method column to table header**
+   - Position after "Email Address" column
+   - Include proper scope attribute for accessibility
+
+4. **Create auth method badge styles** (CSS)
+   - Green badge for OAuth: `auth-badge oauth` with `bg-success` styling
+   - Gray badge for IMAP: `auth-badge imap` with `bg-secondary` styling
+   - Neutral badge for Not Configured: `auth-badge not-configured` with `bg-light text-dark` styling
+
+5. **Update renderAccountsTable() JavaScript function**
+   - Create auth method cell after email cell
+   - Normalize auth_method to lowercase for comparison
+   - Render appropriate badge based on value:
+     - "oauth" (case-insensitive) -> green "OAuth Connected"
+     - "imap" (case-insensitive) -> gray "IMAP"
+     - null/undefined/other -> neutral "Not Configured"
+   - Add aria-label attribute to each badge
+
+## Edge Cases to Handle
+
+- **Null auth_method**: Display "Not Configured" badge
+- **Missing auth_method field**: Display "Not Configured" badge
+- **Unexpected values**: Display "Not Configured" badge (fallback)
+- **Case sensitivity**: Normalize to lowercase before comparison
+- **Empty accounts list**: Table headers still visible including Auth Method
+- **Responsive design**: Include data-label for mobile layout
+
+## Badge Specification Table
+
+| auth_method Value | Badge Text | Color | CSS Classes | aria-label |
+|-------------------|------------|-------|-------------|------------|
+| "oauth" | OAuth Connected | Green | auth-badge oauth | Authentication method: OAuth Connected |
+| "imap" | IMAP | Gray | auth-badge imap | Authentication method: IMAP |
+| null/undefined/other | Not Configured | Neutral | auth-badge not-configured | Authentication method: Not Configured |
+</requirements>
+
+<context>
+**BDD Specification**: specs/BDD-SPEC-oauth-status-badge.md
+**Gap Analysis**: specs/GAP-ANALYSIS-oauth-status-badge.md
+
+## Reuse Opportunities (from gap analysis)
+
+1. **Database schema is complete** - `EmailAccount.auth_method` column already exists in `models/database.py`
+2. **Badge CSS pattern** - Existing `.status-badge` class in accounts.html can be adapted
+3. **Table cell creation pattern** - Follow existing DOM manipulation in `renderAccountsTable()`
+4. **Pydantic optional field pattern** - Follow existing `display_name` field pattern
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `models/account_models.py` | Add auth_method field to EmailAccountInfo |
+| `api_service.py` | Include auth_method in account mapping (~line 1856) |
+| `frontend/templates/accounts.html` | Add column, CSS, JavaScript badge logic |
+
+## New Components Needed
+
+None - all changes are additions to existing files.
+</context>
+
+<implementation>
+Follow TDD approach:
+1. Tests will be created from Gherkin scenarios
+2. Implement code to make tests pass
+3. Ensure all 17 scenarios are green
+
+## Implementation Order
+
+### Phase 1: Backend (API Response)
+1. Add `auth_method` field to `EmailAccountInfo` model
+2. Update endpoint mapping in `api_service.py` to include auth_method
+3. Verify API returns auth_method for all accounts
+
+### Phase 2: Frontend (Column and Badge Display)
+1. Add "Auth Method" column header to table (after Email Address)
+2. Add CSS styles for auth badges
+3. Update `renderAccountsTable()` to create auth method cell with badge
+4. Implement badge selection logic (oauth/imap/not-configured)
+5. Add aria-labels for accessibility
+
+## Architecture Guidelines
+
+- Follow strict-architecture rules (500 lines max, interfaces, no env vars in functions)
+- Use existing patterns from codebase
+- Maintain consistency with project structure
+- Keep frontend JavaScript in template (matching existing pattern)
+</implementation>
+
+<verification>
+All Gherkin scenarios must pass:
+
+### Happy Paths
+- [ ] Scenario: OAuth Connected account displays green badge
+- [ ] Scenario: IMAP account displays gray badge
+- [ ] Scenario: Accounts list shows mixed authentication methods
+- [ ] Scenario: Auth Method column is visible in accounts table
+
+### Edge Cases
+- [ ] Scenario: Legacy account with null auth_method displays Not Configured badge
+- [ ] Scenario: Empty accounts list renders correctly
+- [ ] Scenario: Case insensitive auth_method handling
+
+### API Response Behavior
+- [ ] Scenario: API response includes auth_method for each account
+- [ ] Scenario: OAuth account returns oauth auth_method in API response
+- [ ] Scenario: IMAP account returns imap auth_method in API response
+- [ ] Scenario: Legacy account returns null auth_method in API response
+
+### Error Handling
+- [ ] Scenario: Badge renders gracefully for unexpected auth_method value
+- [ ] Scenario: Badge renders when auth_method field is missing from response
+
+### Accessibility
+- [ ] Scenario: OAuth badge has accessible aria-label
+- [ ] Scenario: IMAP badge has accessible aria-label
+- [ ] Scenario: Not Configured badge has accessible aria-label
+- [ ] Scenario: Auth Method column header is accessible
+</verification>
+
+<success_criteria>
+- All 17 Gherkin scenarios pass
+- Code follows project coding standards
+- Tests provide complete coverage of scenarios
+- Implementation matches user's confirmed intent:
+  - Green "OAuth Connected" badge for OAuth accounts
+  - Gray "IMAP" badge for IMAP accounts
+  - Neutral "Not Configured" badge for legacy/null accounts
+  - Auth Method column positioned after Email column
+  - All badges have appropriate aria-labels for accessibility
+</success_criteria>

--- a/repositories/database_repository_interface.py
+++ b/repositories/database_repository_interface.py
@@ -290,13 +290,13 @@ class DatabaseRepositoryInterface(ABC):
         pass
     
     @abstractmethod
-    def get_all_accounts(self, active_only: bool = False) -> List[Any]:
+    def get_all_accounts(self, active_only: bool) -> List[Any]:
         """
         Get all email accounts.
-        
+
         Args:
             active_only: If True, only return active accounts
-            
+
         Returns:
             List of EmailAccount entities
         """

--- a/repositories/mysql_repository.py
+++ b/repositories/mysql_repository.py
@@ -644,7 +644,7 @@ class MySQLRepository(DatabaseRepositoryInterface):
         """Get email account by email address"""
         return self.find_one(EmailAccount, email_address=email_address)
     
-    def get_all_accounts(self, active_only: bool = False) -> List[EmailAccount]:
+    def get_all_accounts(self, active_only: bool) -> List[EmailAccount]:
         """Get all email accounts"""
         session = self._get_session()
         try:

--- a/repositories/sqlalchemy_repository.py
+++ b/repositories/sqlalchemy_repository.py
@@ -383,14 +383,14 @@ class SQLAlchemyRepository(DatabaseRepositoryInterface):
         """Get email account by email address"""
         return self.find_one(EmailAccount, email_address=email_address)
     
-    def get_all_accounts(self, active_only: bool = False) -> List[EmailAccount]:
+    def get_all_accounts(self, active_only: bool) -> List[EmailAccount]:
         """Get all email accounts"""
         session = self._get_session()
         query = session.query(EmailAccount)
-        
+
         if active_only:
             query = query.filter_by(is_active=True)
-        
+
         return query.order_by(EmailAccount.email_address).all()
     
     def create_or_update_account(

--- a/services/background_processor_service.py
+++ b/services/background_processor_service.py
@@ -97,7 +97,7 @@ class BackgroundProcessorService(BackgroundProcessorInterface):
                 try:
                     # Use the shared repository instance
                     service = AccountCategoryClient(repository=self.repository)
-                    accounts = service.get_all_accounts()
+                    accounts = service.get_all_accounts(active_only=True)
 
                     if not accounts:
                         logger.info("📭 No Gmail accounts found in database to process")

--- a/services/email_summary_service.py
+++ b/services/email_summary_service.py
@@ -127,7 +127,7 @@ class EmailSummaryService:
         if self.account_service and self.gmail_email:
             try:
                 # Create account and get its ID, but don't keep reference to avoid session issues
-                account = self.account_service.get_or_create_account(self.gmail_email)
+                account = self.account_service.get_or_create_account(self.gmail_email, None, None, None, None)
                 self.current_account_id = account.id
                 account_id = account.id  # Store ID before account object goes out of scope
                 logger.info(f"Processing run linked to account: {self.gmail_email} (ID: {account_id})")

--- a/services/email_summary_service.py
+++ b/services/email_summary_service.py
@@ -127,7 +127,7 @@ class EmailSummaryService:
         if self.account_service and self.gmail_email:
             try:
                 # Create account and get its ID, but don't keep reference to avoid session issues
-                account = self.account_service.get_or_create_account(self.gmail_email, None, None, None, None)
+                account = self.account_service.get_or_create_account(self.gmail_email, None, None, None, None, None)
                 self.current_account_id = account.id
                 account_id = account.id  # Store ID before account object goes out of scope
                 logger.info(f"Processing run linked to account: {self.gmail_email} (ID: {account_id})")

--- a/services/gmail_fetcher_service.py
+++ b/services/gmail_fetcher_service.py
@@ -74,7 +74,8 @@ class GmailFetcher(GmailFetcherInterface):
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
+            # Mark as IMAP authentication with the app password
+            self.account_service.get_or_create_account(self.email_address, None, app_password, 'imap', None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/services/gmail_fetcher_service.py
+++ b/services/gmail_fetcher_service.py
@@ -74,7 +74,7 @@ class GmailFetcher(GmailFetcherInterface):
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
+            self.account_service.get_or_create_account(self.email_address, None, None, None, None, None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/services/gmail_fetcher_service.py
+++ b/services/gmail_fetcher_service.py
@@ -74,7 +74,7 @@ class GmailFetcher(GmailFetcherInterface):
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address)
+            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/services/gmail_fetcher_service.py
+++ b/services/gmail_fetcher_service.py
@@ -74,7 +74,7 @@ class GmailFetcher(GmailFetcherInterface):
         try:
             self.account_service = AccountCategoryClient()
             # Register/activate the account (don't store the returned object to avoid session issues)
-            self.account_service.get_or_create_account(self.email_address, None, None, None, None, None)
+            self.account_service.get_or_create_account(self.email_address, None, None, None, None)
             logger.info(f"Account registered for category tracking: {self.email_address}")
         except Exception as e:
             logger.error(f"Failed to initialize AccountCategoryClient for {self.email_address}: {str(e)}")

--- a/specs/BDD-SPEC-oauth-status-badge.md
+++ b/specs/BDD-SPEC-oauth-status-badge.md
@@ -1,0 +1,109 @@
+# BDD Specification: OAuth Status Badge on Accounts Page
+
+## Overview
+
+This feature adds a visual indicator on the Accounts page showing the authentication method for each email account. Users can quickly identify which accounts are connected via OAuth (green "OAuth Connected" badge) and which use IMAP credentials (gray "IMAP" badge). Legacy accounts with no configured authentication method display a neutral "Not Configured" badge.
+
+## Root Request
+
+> "Add a visual indicator on the Accounts page showing Gmail OAuth connection status. The accounts table should display whether each account is connected via OAuth (showing a green 'OAuth Connected' badge) or using IMAP credentials (showing a gray 'IMAP' badge). The frontend should call the existing /api/accounts/{email}/oauth-status endpoint to get connection status, or ideally include auth_method in the /api/accounts response to avoid extra API calls per account."
+
+## User Stories
+
+- As a user of the email management system, I want to see the authentication method for each account on the Accounts page, so that I can quickly identify which accounts use OAuth and which use IMAP.
+
+## Feature Files
+
+| Feature File | Scenarios | Coverage |
+|--------------|-----------|----------|
+| oauth-status-badge.feature | 17 | Happy paths, edge cases, API response, error handling, accessibility |
+
+## Scenarios Summary
+
+### oauth-status-badge.feature
+
+#### Happy Paths (4 scenarios)
+1. **OAuth Connected account displays green badge** - Account with auth_method "oauth" shows green "OAuth Connected" badge
+2. **IMAP account displays gray badge** - Account with auth_method "imap" shows gray "IMAP" badge
+3. **Accounts list shows mixed authentication methods** - Table correctly displays different badges for different account types
+4. **Auth Method column is visible in accounts table** - Column header present, positioned after Email column
+
+#### Edge Cases (3 scenarios)
+5. **Legacy account with null auth_method displays Not Configured badge** - Null/legacy accounts show neutral badge
+6. **Empty accounts list renders correctly** - Table renders headers with no data rows
+7. **Case insensitive auth_method handling** - "OAuth" and "oauth" both render green badge
+
+#### API Response Behavior (4 scenarios)
+8. **API response includes auth_method for each account** - Every account has auth_method field
+9. **OAuth account returns oauth auth_method in API response** - OAuth accounts return "oauth"
+10. **IMAP account returns imap auth_method in API response** - IMAP accounts return "imap"
+11. **Legacy account returns null auth_method in API response** - Legacy accounts return null
+
+#### Error Handling (2 scenarios)
+12. **Badge renders gracefully for unexpected auth_method value** - Unknown values show "Not Configured"
+13. **Badge renders when auth_method field is missing from response** - Missing field shows "Not Configured"
+
+#### Accessibility (4 scenarios)
+14. **OAuth badge has accessible aria-label** - "Authentication method: OAuth Connected"
+15. **IMAP badge has accessible aria-label** - "Authentication method: IMAP"
+16. **Not Configured badge has accessible aria-label** - "Authentication method: Not Configured"
+17. **Auth Method column header is accessible** - Proper table header scope
+
+## Badge Specifications
+
+| auth_method Value | Badge Text | Badge Color | CSS Class | aria-label |
+|-------------------|------------|-------------|-----------|------------|
+| "oauth" | OAuth Connected | Green | bg-success | Authentication method: OAuth Connected |
+| "imap" | IMAP | Gray | bg-secondary | Authentication method: IMAP |
+| null / undefined / unexpected | Not Configured | Neutral | bg-light text-dark | Authentication method: Not Configured |
+
+## Column Position
+
+The "Auth Method" column should appear **after the Email column** as the second data column. Rationale:
+- Authentication method is a fundamental property of account identity
+- Users scanning the table want to quickly see: "Which account? How is it connected?"
+- Follows pattern of "identity first, then status, then operational details"
+
+## Acceptance Criteria
+
+### Backend
+- [ ] GET /api/accounts response includes `auth_method` field for each account
+- [ ] OAuth accounts return `auth_method: "oauth"`
+- [ ] IMAP accounts return `auth_method: "imap"`
+- [ ] Legacy accounts return `auth_method: null`
+
+### Frontend
+- [ ] Accounts table displays "Auth Method" column header
+- [ ] Column positioned after Email column
+- [ ] OAuth accounts show green "OAuth Connected" badge
+- [ ] IMAP accounts show gray "IMAP" badge
+- [ ] Null/undefined/unexpected values show neutral "Not Configured" badge
+- [ ] Case insensitive handling (normalize to lowercase)
+- [ ] Empty table renders correctly with headers
+
+### Accessibility
+- [ ] All badges have appropriate aria-labels
+- [ ] Column header has proper table header scope
+- [ ] Screen readers can identify badge meaning
+
+## Dependencies
+
+- Existing `EmailAccount` database model with `auth_method` column
+- Existing GET /api/accounts endpoint structure
+- Bootstrap CSS classes for badge styling (bg-success, bg-secondary, bg-light)
+
+## Out of Scope
+
+- OAuth token refresh status (valid/expired)
+- OAuth connection/disconnection actions
+- IMAP credential management
+
+## Related Files
+
+- `models/account_models.py` - EmailAccountInfo model
+- `api_service.py` - GET /api/accounts endpoint
+- `frontend/templates/accounts.html` - Accounts page template
+
+---
+
+**Ready for**: gherkin-to-test agent

--- a/specs/DRAFT-oauth-status-badge.md
+++ b/specs/DRAFT-oauth-status-badge.md
@@ -1,0 +1,195 @@
+# DRAFT Spec: OAuth Status Badge on Accounts Page
+
+## Summary
+Add a visual indicator on the Accounts page showing Gmail OAuth connection status. The accounts table displays whether each account is connected via OAuth (green "OAuth Connected" badge) or using IMAP credentials (gray "IMAP" badge).
+
+## Root Request
+> "Add a visual indicator on the Accounts page showing Gmail OAuth connection status. The accounts table should display whether each account is connected via OAuth (showing a green 'OAuth Connected' badge) or using IMAP credentials (showing a gray 'IMAP' badge). The frontend should call the existing /api/accounts/{email}/oauth-status endpoint to get connection status, or ideally include auth_method in the /api/accounts response to avoid extra API calls per account."
+
+---
+
+## Interfaces Needed
+
+### 1. IAuthMethodBadgeRenderer (Frontend Interface)
+**Purpose**: Renders the appropriate badge based on auth_method value.
+
+```typescript
+interface IAuthMethodBadgeRenderer {
+    /**
+     * Renders HTML for auth method badge
+     * @param authMethod - "oauth" | "imap" | null
+     * @returns HTML string for badge element
+     */
+    renderBadge(authMethod: string | null): string;
+}
+```
+
+### 2. IEmailAccountInfoExtended (API Response Model)
+**Purpose**: Extended account info response that includes auth_method field.
+
+```python
+class IEmailAccountInfoExtended(Protocol):
+    """Protocol for email account info with auth method"""
+    email: str
+    is_active: bool
+    auth_method: Optional[str]  # "oauth" or "imap"
+    # ... other existing fields
+```
+
+---
+
+## Data Models
+
+### 1. EmailAccountInfo (Modified Response Model)
+**Location**: models/account_models.py
+
+```python
+class EmailAccountInfo(BaseModel):
+    """Email account information for API responses"""
+    email: str
+    is_active: bool
+    fetch_interval_minutes: int
+    max_emails_per_fetch: int
+    last_successful_fetch: Optional[datetime] = None
+    auth_method: Optional[str] = None  # NEW FIELD: "oauth" or "imap"
+
+    class Config:
+        from_attributes = True
+```
+
+### 2. Badge Display Constants (Frontend)
+**Location**: frontend/templates/accounts.html (inline JavaScript)
+
+```javascript
+const AUTH_METHOD_BADGES = {
+    oauth: {
+        text: "OAuth Connected",
+        cssClass: "badge bg-success"
+    },
+    imap: {
+        text: "IMAP",
+        cssClass: "badge bg-secondary"
+    },
+    unknown: {
+        text: "Unknown",
+        cssClass: "badge bg-light text-dark"
+    }
+};
+```
+
+---
+
+## Logic Flow
+
+### Backend: GET /api/accounts Enhancement
+
+```pseudocode
+FUNCTION get_accounts(request):
+    accounts = database.get_all_email_accounts()
+
+    response_list = []
+    FOR account IN accounts:
+        account_info = EmailAccountInfo(
+            email = account.email,
+            is_active = account.is_active,
+            fetch_interval_minutes = account.fetch_interval_minutes,
+            max_emails_per_fetch = account.max_emails_per_fetch,
+            last_successful_fetch = account.last_successful_fetch,
+            auth_method = account.auth_method  # NEW: include from database
+        )
+        response_list.append(account_info)
+
+    RETURN response_list
+```
+
+### Frontend: Badge Rendering
+
+```pseudocode
+FUNCTION renderAuthMethodBadge(authMethod):
+    IF authMethod == "oauth":
+        RETURN '<span class="badge bg-success">OAuth Connected</span>'
+    ELSE IF authMethod == "imap":
+        RETURN '<span class="badge bg-secondary">IMAP</span>'
+    ELSE:
+        RETURN '<span class="badge bg-light text-dark">Unknown</span>'
+```
+
+### Frontend: Table Column Addition
+
+```pseudocode
+FUNCTION renderAccountsTable(accounts):
+    FOR account IN accounts:
+        row = CREATE table_row
+        row.append(cell(account.email))
+        row.append(cell(account.is_active))
+        row.append(cell(renderAuthMethodBadge(account.auth_method)))  # NEW COLUMN
+        row.append(cell(account.fetch_interval_minutes))
+        row.append(cell(account.last_successful_fetch))
+        row.append(cell(action_buttons))
+        table.append(row)
+```
+
+---
+
+## File Changes Summary
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| models/account_models.py | Modify | Add `auth_method: Optional[str]` field to EmailAccountInfo |
+| api_service.py | Modify | Include `auth_method=account.auth_method` in GET /api/accounts response construction |
+| frontend/templates/accounts.html | Modify | Add "Auth Method" column header to table |
+| frontend/templates/accounts.html | Modify | Update renderAccountsTable() to display badge for auth_method |
+
+---
+
+## Context Budget
+
+| Category | Estimate |
+|----------|----------|
+| Files to read | 4 files (~400 lines) |
+| New code to write | ~30 lines |
+| Test code to write | ~80 lines |
+| Estimated context usage | **15%** |
+
+**Assessment**: Well within the 60% limit. This is a small, focused feature.
+
+---
+
+## Test Scenarios
+
+### Backend Tests
+1. **API returns auth_method in response**: Verify GET /api/accounts includes auth_method for each account
+2. **OAuth account shows "oauth"**: Account with auth_method="oauth" returns "oauth" in response
+3. **IMAP account shows "imap"**: Account with auth_method="imap" returns "imap" in response
+4. **Null auth_method handled**: Account with NULL auth_method returns null/None in response
+
+### Frontend Tests (Manual/E2E)
+1. **OAuth badge displayed**: Account with auth_method="oauth" shows green "OAuth Connected" badge
+2. **IMAP badge displayed**: Account with auth_method="imap" shows gray "IMAP" badge
+3. **Unknown badge displayed**: Account with null auth_method shows neutral "Unknown" badge
+4. **Column alignment**: Auth Method column aligns properly with other table columns
+
+---
+
+## Edge Cases
+
+1. **Legacy accounts with NULL auth_method**: Display "Unknown" badge
+2. **Mixed account types**: Table correctly shows different badges for different accounts
+3. **Empty accounts list**: Table renders correctly with no rows
+4. **Case sensitivity**: Handle both "OAuth" and "oauth" consistently (normalize to lowercase)
+
+---
+
+## Dependencies
+
+- Existing EmailAccount database model already has `auth_method` column
+- Existing GET /api/accounts endpoint structure
+- Bootstrap CSS classes for badge styling (bg-success, bg-secondary, bg-light)
+
+---
+
+## Out of Scope
+
+- OAuth token refresh status (valid/expired) - use existing oauth-status endpoint for detailed info
+- OAuth connection/disconnection actions - handled by existing OAuth flow
+- IMAP credential management - existing functionality

--- a/specs/GAP-ANALYSIS-oauth-status-badge.md
+++ b/specs/GAP-ANALYSIS-oauth-status-badge.md
@@ -1,0 +1,171 @@
+# Gap Analysis: OAuth Status Badge on Accounts Page
+
+## Overview
+
+This document analyzes the existing codebase to identify reuse opportunities and new components needed to implement the OAuth Status Badge feature.
+
+## Root Request
+
+> "Add a visual indicator on the Accounts page showing Gmail OAuth connection status. The accounts table should display whether each account is connected via OAuth (showing a green 'OAuth Connected' badge) or using IMAP credentials (showing a gray 'IMAP' badge)."
+
+## Existing Code Analysis
+
+### Database Layer - COMPLETE
+
+**File**: `/root/repo/models/database.py` (lines 31-60)
+
+The `EmailAccount` model already has the required `auth_method` column:
+
+```python
+class EmailAccount(Base):
+    __tablename__ = 'email_accounts'
+    # ...
+    auth_method = Column(String(20), default='imap')  # 'imap' or 'oauth'
+    # ...
+    __table_args__ = (
+        Index('idx_auth_method', 'auth_method'),
+    )
+```
+
+**Status**: No changes needed. The column exists with proper indexing.
+
+### API Response Model - NEEDS UPDATE
+
+**File**: `/root/repo/models/account_models.py` (lines 97-123)
+
+The `EmailAccountInfo` Pydantic model currently does NOT include `auth_method`:
+
+```python
+class EmailAccountInfo(BaseModel):
+    id: int
+    email_address: str
+    display_name: Optional[str]
+    masked_password: Optional[str]
+    password_length: int
+    is_active: bool
+    last_scan_at: Optional[datetime]
+    created_at: datetime
+    # MISSING: auth_method field
+```
+
+**Action Required**: Add `auth_method: Optional[str]` field to the model.
+
+### API Endpoint - NEEDS UPDATE
+
+**File**: `/root/repo/api_service.py` (lines 1846-1857)
+
+The `get_all_accounts` endpoint maps database fields to `EmailAccountInfo`:
+
+```python
+account_infos = [
+    EmailAccountInfo(
+        id=account.id,
+        email_address=account.email_address,
+        display_name=account.display_name,
+        masked_password=mask_password(account.app_password),
+        password_length=len(account.app_password) if account.app_password else 0,
+        is_active=account.is_active,
+        last_scan_at=account.last_scan_at,
+        created_at=account.created_at
+        # MISSING: auth_method=account.auth_method
+    )
+    for account in accounts
+]
+```
+
+**Action Required**: Add `auth_method=account.auth_method` to the mapping.
+
+### Frontend Template - NEEDS UPDATE
+
+**File**: `/root/repo/frontend/templates/accounts.html`
+
+**Reusable Components**:
+
+1. **Badge styling** (lines 66-87): Existing `status-badge` CSS class can be adapted:
+   ```css
+   .status-badge {
+       padding: 0.375rem 0.75rem;
+       border-radius: 1rem;
+       font-size: 0.8125rem;
+       font-weight: 600;
+       display: inline-block;
+       min-width: 5rem;
+       text-align: center;
+   }
+   ```
+
+2. **Table structure** (lines 331-346): Existing table with headers - need to add "Auth Method" column
+
+3. **JavaScript rendering** (lines 476-598): `renderAccountsTable()` function - need to add auth method badge logic
+
+**Action Required**:
+- Add "Auth Method" column header after "Email Address"
+- Add CSS styles for auth method badges (`.auth-badge.oauth`, `.auth-badge.imap`, `.auth-badge.not-configured`)
+- Update `renderAccountsTable()` to create auth method badge cell
+- Add aria-labels for accessibility
+
+## Components Summary
+
+| Component | File | Status | Action |
+|-----------|------|--------|--------|
+| Database schema | models/database.py | Complete | None |
+| API response model | models/account_models.py | Needs update | Add auth_method field |
+| API endpoint mapping | api_service.py | Needs update | Include auth_method in mapping |
+| Table column header | frontend/templates/accounts.html | Needs update | Add "Auth Method" column |
+| Badge CSS styles | frontend/templates/accounts.html | Needs update | Add auth badge styles |
+| Badge rendering JS | frontend/templates/accounts.html | Needs update | Create badge in table rows |
+| Accessibility | frontend/templates/accounts.html | Needs update | Add aria-labels |
+
+## Reuse Patterns
+
+### Pattern 1: Badge Styling
+Copy existing `status-badge` pattern for `auth-badge`:
+- `.auth-badge.oauth` - Green badge (similar to `.status-badge.active`)
+- `.auth-badge.imap` - Gray badge (similar to `.status-badge.inactive`)
+- `.auth-badge.not-configured` - Neutral badge (new)
+
+### Pattern 2: Table Cell Creation
+Follow existing DOM creation pattern in `renderAccountsTable()`:
+```javascript
+// Existing pattern for cells
+const statusCell = document.createElement('td');
+statusCell.setAttribute('data-label', 'Status');
+const statusBadge = document.createElement('span');
+statusBadge.className = account.is_active ? 'status-badge active' : 'status-badge inactive';
+statusBadge.textContent = account.is_active ? 'Active' : 'Inactive';
+statusCell.appendChild(statusBadge);
+```
+
+### Pattern 3: Pydantic Optional Field
+Follow existing pattern for optional fields in `EmailAccountInfo`:
+```python
+display_name: Optional[str] = Field(
+    None,
+    description="Optional display name for the account"
+)
+```
+
+## Refactoring Decision
+
+**GO SIGNAL: APPROVED**
+
+No refactoring is required before implementation:
+1. Database schema is already in place
+2. Existing code patterns are clean and reusable
+3. Changes are additive, not modifications to existing behavior
+4. All changes follow established project patterns
+
+## Implementation Order
+
+1. **Backend First**: Update `EmailAccountInfo` model and API endpoint
+2. **Frontend Second**: Update template with column, styling, and JavaScript
+
+This order ensures the frontend has data to display when implemented.
+
+## Test Coverage Needed
+
+Based on BDD scenarios:
+- Unit tests for API response including auth_method
+- Integration tests for various auth_method values (oauth, imap, null)
+- Frontend tests for badge rendering
+- Accessibility tests for aria-labels

--- a/tests/bdd/oauth-status-badge.feature
+++ b/tests/bdd/oauth-status-badge.feature
@@ -1,0 +1,111 @@
+Feature: OAuth Status Badge on Accounts Page
+  As a user of the email management system
+  I want to see the authentication method for each account on the Accounts page
+  So that I can quickly identify which accounts use OAuth and which use IMAP
+
+  Background:
+    Given the Accounts page is loaded
+    And the accounts list is retrieved from the system
+
+  # === HAPPY PATHS ===
+
+  Scenario: OAuth Connected account displays green badge
+    Given an account "user@gmail.com" has auth_method "oauth"
+    When the accounts table is displayed
+    Then the account "user@gmail.com" should show a green "OAuth Connected" badge
+
+  Scenario: IMAP account displays gray badge
+    Given an account "user@company.com" has auth_method "imap"
+    When the accounts table is displayed
+    Then the account "user@company.com" should show a gray "IMAP" badge
+
+  Scenario: Accounts list shows mixed authentication methods
+    Given the following accounts exist:
+      | email               | auth_method |
+      | oauth1@gmail.com    | oauth       |
+      | imap1@company.com   | imap        |
+      | oauth2@gmail.com    | oauth       |
+    When the accounts table is displayed
+    Then "oauth1@gmail.com" should show a green "OAuth Connected" badge
+    And "imap1@company.com" should show a gray "IMAP" badge
+    And "oauth2@gmail.com" should show a green "OAuth Connected" badge
+
+  Scenario: Auth Method column is visible in accounts table
+    Given accounts exist in the system
+    When the accounts table is displayed
+    Then the table should have an "Auth Method" column header
+    And the "Auth Method" column should appear after the "Email" column
+
+  # === EDGE CASES ===
+
+  Scenario: Legacy account with null auth_method displays Not Configured badge
+    Given an account "legacy@gmail.com" has auth_method null
+    When the accounts table is displayed
+    Then the account "legacy@gmail.com" should show a neutral "Not Configured" badge
+
+  Scenario: Empty accounts list renders correctly
+    Given no accounts exist in the system
+    When the accounts table is displayed
+    Then the table should render with headers but no data rows
+    And the "Auth Method" column header should still be visible
+
+  Scenario: Case insensitive auth_method handling
+    Given an account "user@gmail.com" has auth_method "OAuth"
+    When the accounts table is displayed
+    Then the account "user@gmail.com" should show a green "OAuth Connected" badge
+
+  # === API RESPONSE BEHAVIOR ===
+
+  Scenario: API response includes auth_method for each account
+    Given accounts exist with various authentication methods
+    When the system retrieves the accounts list
+    Then each account in the response should include an auth_method field
+
+  Scenario: OAuth account returns oauth auth_method in API response
+    Given an account "user@gmail.com" is configured with OAuth
+    When the system retrieves the accounts list
+    Then the response for "user@gmail.com" should have auth_method "oauth"
+
+  Scenario: IMAP account returns imap auth_method in API response
+    Given an account "user@company.com" is configured with IMAP credentials
+    When the system retrieves the accounts list
+    Then the response for "user@company.com" should have auth_method "imap"
+
+  Scenario: Legacy account returns null auth_method in API response
+    Given an account "legacy@gmail.com" was created before auth_method tracking
+    When the system retrieves the accounts list
+    Then the response for "legacy@gmail.com" should have auth_method null
+
+  # === ERROR HANDLING ===
+
+  Scenario: Badge renders gracefully for unexpected auth_method value
+    Given an account "user@gmail.com" has auth_method "unexpected_value"
+    When the accounts table is displayed
+    Then the account "user@gmail.com" should show a neutral "Not Configured" badge
+
+  Scenario: Badge renders when auth_method field is missing from response
+    Given an account response is missing the auth_method field
+    When the accounts table is displayed
+    Then the account should show a neutral "Not Configured" badge
+
+  # === ACCESSIBILITY ===
+
+  Scenario: OAuth badge has accessible aria-label
+    Given an account "user@gmail.com" has auth_method "oauth"
+    When the accounts table is displayed
+    Then the badge for "user@gmail.com" should have aria-label "Authentication method: OAuth Connected"
+
+  Scenario: IMAP badge has accessible aria-label
+    Given an account "user@company.com" has auth_method "imap"
+    When the accounts table is displayed
+    Then the badge for "user@company.com" should have aria-label "Authentication method: IMAP"
+
+  Scenario: Not Configured badge has accessible aria-label
+    Given an account "legacy@gmail.com" has auth_method null
+    When the accounts table is displayed
+    Then the badge for "legacy@gmail.com" should have aria-label "Authentication method: Not Configured"
+
+  Scenario: Auth Method column header is accessible
+    Given accounts exist in the system
+    When the accounts table is displayed
+    Then the "Auth Method" column header should have appropriate table header scope

--- a/tests/fake_account_category_client.py
+++ b/tests/fake_account_category_client.py
@@ -45,7 +45,7 @@ class FakeAccountCategoryClient(AccountCategoryClientInterface):
         self.category_stats: Dict[str, List[Dict]] = {}  # email -> list of stats
         self._next_id = 1
 
-    def get_or_create_account(self, email_address: str, display_name: Optional[str], app_password: Optional[str], auth_method: Optional[str]) -> FakeEmailAccount:
+    def get_or_create_account(self, email_address: str, display_name: Optional[str], app_password: Optional[str], auth_method: Optional[str], oauth_refresh_token: Optional[str]) -> FakeEmailAccount:
         """
         Get existing account or create a new one.
 
@@ -54,6 +54,7 @@ class FakeAccountCategoryClient(AccountCategoryClientInterface):
             display_name: Optional display name for the account
             app_password: Optional Gmail app-specific password for IMAP access
             auth_method: Optional authentication method ('oauth', 'imap', or None)
+            oauth_refresh_token: OAuth refresh token (required if auth_method is 'oauth')
 
         Returns:
             EmailAccount object (existing or newly created)

--- a/tests/fake_account_category_client.py
+++ b/tests/fake_account_category_client.py
@@ -29,6 +29,7 @@ class FakeEmailAccount:
     created_at: datetime = field(default_factory=datetime.utcnow)
     last_scan_at: Optional[datetime] = None
     app_password: Optional[str] = None
+    auth_method: Optional[str] = None
 
 
 class FakeAccountCategoryClient(AccountCategoryClientInterface):
@@ -44,7 +45,7 @@ class FakeAccountCategoryClient(AccountCategoryClientInterface):
         self.category_stats: Dict[str, List[Dict]] = {}  # email -> list of stats
         self._next_id = 1
 
-    def get_or_create_account(self, email_address: str, display_name: Optional[str] = None, app_password: Optional[str] = None) -> FakeEmailAccount:
+    def get_or_create_account(self, email_address: str, display_name: Optional[str], app_password: Optional[str], auth_method: Optional[str]) -> FakeEmailAccount:
         """
         Get existing account or create a new one.
 
@@ -52,6 +53,7 @@ class FakeAccountCategoryClient(AccountCategoryClientInterface):
             email_address: Gmail email address
             display_name: Optional display name for the account
             app_password: Optional Gmail app-specific password for IMAP access
+            auth_method: Optional authentication method ('oauth', 'imap', or None)
 
         Returns:
             EmailAccount object (existing or newly created)
@@ -74,6 +76,7 @@ class FakeAccountCategoryClient(AccountCategoryClientInterface):
             email_address=email_address,
             display_name=display_name or email_address,
             app_password=app_password,
+            auth_method=auth_method,
             is_active=True,
             created_at=datetime.utcnow(),
             last_scan_at=None
@@ -247,7 +250,7 @@ class FakeAccountCategoryClient(AccountCategoryClientInterface):
             top_categories=top_categories
         )
 
-    def get_all_accounts(self, active_only: bool = True) -> List[FakeEmailAccount]:
+    def get_all_accounts(self, active_only: bool) -> List[FakeEmailAccount]:
         """
         Get all accounts, optionally filtered by active status.
 

--- a/tests/test_account_category_client_oauth.py
+++ b/tests/test_account_category_client_oauth.py
@@ -41,6 +41,8 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         """Test creating account with OAuth authentication."""
         account = self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            app_password=None,
             auth_method="oauth",
             oauth_refresh_token="test_refresh_token",
         )
@@ -54,6 +56,9 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         """Test that account defaults to IMAP auth method."""
         account = self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            auth_method=None,
+            oauth_refresh_token=None,
             app_password="test_password",
         )
 
@@ -65,6 +70,9 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         # First create an account
         self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            auth_method=None,
+            oauth_refresh_token=None,
             app_password="initial_password",
         )
 
@@ -103,6 +111,8 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         # Create account with OAuth
         self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            app_password=None,
             auth_method="oauth",
             oauth_refresh_token="refresh_token",
         )
@@ -129,6 +139,9 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         """Test getting OAuth status for IMAP-authenticated account."""
         self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            auth_method=None,
+            oauth_refresh_token=None,
             app_password="password",
         )
 
@@ -150,6 +163,8 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         # Create OAuth account
         self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            app_password=None,
             auth_method="oauth",
             oauth_refresh_token="refresh_token",
         )
@@ -184,6 +199,8 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         # Create OAuth account
         self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            app_password=None,
             auth_method="oauth",
             oauth_refresh_token="refresh_token",
         )
@@ -203,12 +220,17 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         # Create IMAP account
         self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            auth_method=None,
+            oauth_refresh_token=None,
             app_password="password",
         )
 
         # Update to OAuth
         account = self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            app_password=None,
             auth_method="oauth",
             oauth_refresh_token="new_refresh_token",
         )
@@ -220,6 +242,8 @@ class TestAccountCategoryClientOAuth(unittest.TestCase):
         """Test that OAuth scopes are stored as JSON and retrieved as list."""
         self.service.get_or_create_account(
             email_address=self.test_email,
+            display_name=None,
+            app_password=None,
             auth_method="oauth",
             oauth_refresh_token="token",
         )

--- a/tests/test_account_category_service.py
+++ b/tests/test_account_category_service.py
@@ -94,12 +94,12 @@ class TestAccountCategoryClient(unittest.TestCase):
     def test_create_or_update_account(self):
         """Test get_or_create_account method."""
         # First creation
-        account1 = self.service.get_or_create_account(self.test_email, None, None, None)
+        account1 = self.service.get_or_create_account(self.test_email, None, None, None, None)
         self.assertIsNotNone(account1)
         self.assertEqual(account1.email_address, self.test_email)
 
         # Update existing
-        account2 = self.service.get_or_create_account(self.test_email, None, None, None)
+        account2 = self.service.get_or_create_account(self.test_email, None, None, None, None)
         self.assertIsNotNone(account2)
         self.assertEqual(account2.id, account1.id)  # Should be same account
 

--- a/tests/test_account_category_service.py
+++ b/tests/test_account_category_service.py
@@ -94,12 +94,12 @@ class TestAccountCategoryClient(unittest.TestCase):
     def test_create_or_update_account(self):
         """Test get_or_create_account method."""
         # First creation
-        account1 = self.service.get_or_create_account(self.test_email)
+        account1 = self.service.get_or_create_account(self.test_email, None, None, None)
         self.assertIsNotNone(account1)
         self.assertEqual(account1.email_address, self.test_email)
 
         # Update existing
-        account2 = self.service.get_or_create_account(self.test_email)
+        account2 = self.service.get_or_create_account(self.test_email, None, None, None)
         self.assertIsNotNone(account2)
         self.assertEqual(account2.id, account1.id)  # Should be same account
 

--- a/tests/test_account_deletion_integration.py
+++ b/tests/test_account_deletion_integration.py
@@ -52,7 +52,7 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         """Test deletion of account without associated data."""
         # Create an account
         email = "test@example.com"
-        account = self.client.get_or_create_account(email, "Test User")
+        account = self.client.get_or_create_account(email, "Test User", None, None)
         self.assertIsNotNone(account)
 
         # Verify account exists
@@ -71,7 +71,7 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         """Test deletion of account with associated category statistics."""
         # Create an account
         email = "test@example.com"
-        account = self.client.get_or_create_account(email, "Test User")
+        account = self.client.get_or_create_account(email, "Test User", None, None)
 
         # Add some category stats
         stats_date = date.today()
@@ -104,7 +104,7 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         """Test that deleting account cascades to delete all associated stats."""
         # Create an account
         email = "cascade@example.com"
-        account = self.client.get_or_create_account(email, "Cascade Test")
+        account = self.client.get_or_create_account(email, "Cascade Test", None, None)
         account_id = account.id
 
         # Add category stats for multiple days
@@ -134,9 +134,9 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         email2 = "user2@example.com"
         email3 = "user3@example.com"
 
-        account1 = self.client.get_or_create_account(email1, "User 1")
-        account2 = self.client.get_or_create_account(email2, "User 2")
-        account3 = self.client.get_or_create_account(email3, "User 3")
+        account1 = self.client.get_or_create_account(email1, "User 1", None, None)
+        account2 = self.client.get_or_create_account(email2, "User 2", None, None)
+        account3 = self.client.get_or_create_account(email3, "User 3", None, None)
 
         # Add stats to all accounts
         stats_date = date.today()
@@ -179,7 +179,7 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         """Test deletion of deactivated account works correctly."""
         # Create and deactivate an account
         email = "inactive@example.com"
-        account = self.client.get_or_create_account(email, "Inactive User")
+        account = self.client.get_or_create_account(email, "Inactive User", None, None)
 
         # Deactivate it
         result = self.client.deactivate_account(email)
@@ -201,7 +201,7 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         email = "recreate@example.com"
 
         # Create account first time
-        account1 = self.client.get_or_create_account(email, "Original User")
+        account1 = self.client.get_or_create_account(email, "Original User", None, None)
         original_id = account1.id
 
         # Delete it
@@ -209,7 +209,7 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         self.assertTrue(result)
 
         # Create account again with same email
-        account2 = self.client.get_or_create_account(email, "New User")
+        account2 = self.client.get_or_create_account(email, "New User", None, None)
         new_id = account2.id
 
         # Verify it's a new account (may reuse ID in SQLite, but should have new data)
@@ -224,7 +224,7 @@ class TestAccountDeletionIntegration(unittest.TestCase):
         # We'll create an account and then test error handling
 
         email = "rollback@example.com"
-        account = self.client.get_or_create_account(email, "Rollback Test")
+        account = self.client.get_or_create_account(email, "Rollback Test", None, None)
 
         # Create a new session for the second client
         Session = sessionmaker(bind=self.engine)

--- a/tests/test_account_email_processor_service.py
+++ b/tests/test_account_email_processor_service.py
@@ -141,7 +141,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_no_password(self):
         """Test process_account when account has no app password configured."""
         # Setup - create account without app password
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = None
 
         # Execute
@@ -163,7 +163,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_success(self):
         """Test successful email processing workflow."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -207,7 +207,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_fetcher_exception(self):
         """Test process_account when fetcher raises an exception."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -239,7 +239,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_no_new_emails(self):
         """Test process_account when no new emails are found."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -272,7 +272,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_category_stats_recording(self):
         """Test that category statistics are recorded after processing."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -356,7 +356,7 @@ class TestAccountEmailProcessorServiceStatusUpdates(unittest.TestCase):
         # Setup
         fake = Faker()
         test_email = fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None, None)
         account.app_password = fake.password(length=16)
         self.mock_settings_service.get_lookback_hours.return_value = 2
 

--- a/tests/test_account_email_processor_service.py
+++ b/tests/test_account_email_processor_service.py
@@ -141,7 +141,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_no_password(self):
         """Test process_account when account has no app password configured."""
         # Setup - create account without app password
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = None
 
         # Execute
@@ -163,7 +163,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_success(self):
         """Test successful email processing workflow."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -207,7 +207,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_fetcher_exception(self):
         """Test process_account when fetcher raises an exception."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -239,7 +239,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_no_new_emails(self):
         """Test process_account when no new emails are found."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -272,7 +272,7 @@ class TestAccountEmailProcessorService(unittest.TestCase):
     def test_process_account_category_stats_recording(self):
         """Test that category statistics are recorded after processing."""
         # Setup account with app password
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = self.test_password
 
         # Setup settings
@@ -356,7 +356,7 @@ class TestAccountEmailProcessorServiceStatusUpdates(unittest.TestCase):
         # Setup
         fake = Faker()
         test_email = fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
         account.app_password = fake.password(length=16)
         self.mock_settings_service.get_lookback_hours.return_value = 2
 

--- a/tests/test_account_with_app_password.py
+++ b/tests/test_account_with_app_password.py
@@ -70,6 +70,8 @@ class TestAccountWithAppPassword(unittest.TestCase):
         # Create account with app_password
         account = self.client.get_or_create_account(
             email_address=test_email,
+            auth_method=None,
+            oauth_refresh_token=None,
             display_name=test_display_name,
             app_password=test_password
         )
@@ -91,6 +93,8 @@ class TestAccountWithAppPassword(unittest.TestCase):
         # Create account with initial password
         account1 = self.client.get_or_create_account(
             email_address=test_email,
+            auth_method=None,
+            oauth_refresh_token=None,
             display_name=initial_display_name,
             app_password=initial_password
         )
@@ -102,6 +106,9 @@ class TestAccountWithAppPassword(unittest.TestCase):
         new_password = self._generate_password()
         account2 = self.client.get_or_create_account(
             email_address=test_email,
+            display_name=None,
+            auth_method=None,
+            oauth_refresh_token=None,
             app_password=new_password
         )
 
@@ -119,6 +126,9 @@ class TestAccountWithAppPassword(unittest.TestCase):
         # Create account without app_password
         account = self.client.get_or_create_account(
             email_address=test_email,
+            app_password=None,
+            auth_method=None,
+            oauth_refresh_token=None,
             display_name=test_display_name
             # No app_password parameter
         )
@@ -140,6 +150,8 @@ class TestAccountWithAppPassword(unittest.TestCase):
         # Create account with password
         account1 = self.client.get_or_create_account(
             email_address=test_email,
+            auth_method=None,
+            oauth_refresh_token=None,
             display_name=initial_display_name,
             app_password=test_password
         )
@@ -147,6 +159,9 @@ class TestAccountWithAppPassword(unittest.TestCase):
         # Update account with new display name but no password
         account2 = self.client.get_or_create_account(
             email_address=test_email,
+            app_password=None,
+            auth_method=None,
+            oauth_refresh_token=None,
             display_name=new_display_name
             # No app_password - should preserve existing
         )
@@ -165,6 +180,8 @@ class TestAccountWithAppPassword(unittest.TestCase):
         # Create account with app_password
         created_account = self.client.get_or_create_account(
             email_address=test_email,
+            auth_method=None,
+            oauth_refresh_token=None,
             display_name=test_display_name,
             app_password=test_password
         )
@@ -190,6 +207,8 @@ class TestAccountWithAppPassword(unittest.TestCase):
 
             account = self.client.get_or_create_account(
                 email_address=email,
+                auth_method=None,
+                oauth_refresh_token=None,
                 display_name=display_name,
                 app_password=password
             )

--- a/tests/test_accounts_endpoint_password_length.py
+++ b/tests/test_accounts_endpoint_password_length.py
@@ -50,13 +50,13 @@ class TestAccountsEndpointPasswordLength(unittest.TestCase):
         fake_client = FakeAccountCategoryClient()
         
         # Create test accounts with different password scenarios
-        account1 = fake_client.get_or_create_account("test1@gmail.com")
+        account1 = fake_client.get_or_create_account("test1@gmail.com", None, None, None)
         account1.app_password = "abcdefghijklmnop"  # 16 characters
         
-        account2 = fake_client.get_or_create_account("test2@gmail.com")
+        account2 = fake_client.get_or_create_account("test2@gmail.com", None, None, None)
         account2.app_password = None  # No password
         
-        account3 = fake_client.get_or_create_account("test3@gmail.com") 
+        account3 = fake_client.get_or_create_account("test3@gmail.com", None, None, None) 
         account3.app_password = "verylongpassword123456"  # 22 characters
         
         # Override the dependency to use our fake client
@@ -118,9 +118,9 @@ class TestAccountsEndpointPasswordLength(unittest.TestCase):
         """Test that password_length is 0 when account has no password."""
         # Create a client with only accounts without passwords
         fake_client = FakeAccountCategoryClient()
-        account1 = fake_client.get_or_create_account("nopass1@gmail.com")
+        account1 = fake_client.get_or_create_account("nopass1@gmail.com", None, None, None)
         account1.app_password = None
-        account2 = fake_client.get_or_create_account("nopass2@gmail.com")
+        account2 = fake_client.get_or_create_account("nopass2@gmail.com", None, None, None)
         account2.app_password = ""  # Empty string should also be 0
         
         # Override the dependency
@@ -156,7 +156,7 @@ class TestAccountsEndpointPasswordLength(unittest.TestCase):
         ]
         
         for email, password, expected_length in test_cases:
-            account = fake_client.get_or_create_account(email)
+            account = fake_client.get_or_create_account(email, None, None, None)
             account.app_password = password
             
         # Override the dependency

--- a/tests/test_accounts_endpoint_password_length.py
+++ b/tests/test_accounts_endpoint_password_length.py
@@ -50,13 +50,13 @@ class TestAccountsEndpointPasswordLength(unittest.TestCase):
         fake_client = FakeAccountCategoryClient()
         
         # Create test accounts with different password scenarios
-        account1 = fake_client.get_or_create_account("test1@gmail.com", None, None, None)
+        account1 = fake_client.get_or_create_account("test1@gmail.com", None, None, None, None)
         account1.app_password = "abcdefghijklmnop"  # 16 characters
         
-        account2 = fake_client.get_or_create_account("test2@gmail.com", None, None, None)
+        account2 = fake_client.get_or_create_account("test2@gmail.com", None, None, None, None)
         account2.app_password = None  # No password
         
-        account3 = fake_client.get_or_create_account("test3@gmail.com", None, None, None) 
+        account3 = fake_client.get_or_create_account("test3@gmail.com", None, None, None, None) 
         account3.app_password = "verylongpassword123456"  # 22 characters
         
         # Override the dependency to use our fake client
@@ -118,9 +118,9 @@ class TestAccountsEndpointPasswordLength(unittest.TestCase):
         """Test that password_length is 0 when account has no password."""
         # Create a client with only accounts without passwords
         fake_client = FakeAccountCategoryClient()
-        account1 = fake_client.get_or_create_account("nopass1@gmail.com", None, None, None)
+        account1 = fake_client.get_or_create_account("nopass1@gmail.com", None, None, None, None)
         account1.app_password = None
-        account2 = fake_client.get_or_create_account("nopass2@gmail.com", None, None, None)
+        account2 = fake_client.get_or_create_account("nopass2@gmail.com", None, None, None, None)
         account2.app_password = ""  # Empty string should also be 0
         
         # Override the dependency
@@ -156,7 +156,7 @@ class TestAccountsEndpointPasswordLength(unittest.TestCase):
         ]
         
         for email, password, expected_length in test_cases:
-            account = fake_client.get_or_create_account(email, None, None, None)
+            account = fake_client.get_or_create_account(email, None, None, None, None)
             account.app_password = password
             
         # Override the dependency

--- a/tests/test_email_account_app_password_integration.py
+++ b/tests/test_email_account_app_password_integration.py
@@ -90,7 +90,7 @@ class TestEmailAccountAppPasswordIntegration(unittest.TestCase):
         test_password = self.fake.password()
 
         # Create account using real client
-        account = self.real_client.get_or_create_account(test_email)
+        account = self.real_client.get_or_create_account(test_email, None, None, None)
 
         # This should NOT raise AttributeError
         # Set the app_password
@@ -114,7 +114,7 @@ class TestEmailAccountAppPasswordIntegration(unittest.TestCase):
         api_token = self.fake.uuid4()
 
         # Create account with app_password
-        account = self.real_client.get_or_create_account(test_email)
+        account = self.real_client.get_or_create_account(test_email, None, None, None)
         account.app_password = test_password
         self.session.add(account)
         self.session.commit()
@@ -146,7 +146,7 @@ class TestEmailAccountAppPasswordIntegration(unittest.TestCase):
         api_token = self.fake.uuid4()
 
         # Create account WITHOUT app_password
-        account = self.real_client.get_or_create_account(test_email)
+        account = self.real_client.get_or_create_account(test_email, None, None, None)
         # Don't set app_password - it should be None
         self.session.add(account)
         self.session.commit()

--- a/tests/test_email_account_app_password_integration.py
+++ b/tests/test_email_account_app_password_integration.py
@@ -90,7 +90,7 @@ class TestEmailAccountAppPasswordIntegration(unittest.TestCase):
         test_password = self.fake.password()
 
         # Create account using real client
-        account = self.real_client.get_or_create_account(test_email, None, None, None)
+        account = self.real_client.get_or_create_account(test_email, None, None, None, None)
 
         # This should NOT raise AttributeError
         # Set the app_password
@@ -114,7 +114,7 @@ class TestEmailAccountAppPasswordIntegration(unittest.TestCase):
         api_token = self.fake.uuid4()
 
         # Create account with app_password
-        account = self.real_client.get_or_create_account(test_email, None, None, None)
+        account = self.real_client.get_or_create_account(test_email, None, None, None, None)
         account.app_password = test_password
         self.session.add(account)
         self.session.commit()
@@ -146,7 +146,7 @@ class TestEmailAccountAppPasswordIntegration(unittest.TestCase):
         api_token = self.fake.uuid4()
 
         # Create account WITHOUT app_password
-        account = self.real_client.get_or_create_account(test_email, None, None, None)
+        account = self.real_client.get_or_create_account(test_email, None, None, None, None)
         # Don't set app_password - it should be None
         self.session.add(account)
         self.session.commit()

--- a/tests/test_email_account_oauth_columns_integration.py
+++ b/tests/test_email_account_oauth_columns_integration.py
@@ -174,6 +174,8 @@ class TestEmailAccountOAuthColumnsIntegration(unittest.TestCase):
         test_email = 'test_oauth_get_all@example.com'
         account = self.client.get_or_create_account(
             email_address=test_email,
+            app_password=None,
+            oauth_refresh_token=None,
             display_name='Test OAuth User',
             auth_method='imap'
         )
@@ -202,6 +204,7 @@ class TestEmailAccountOAuthColumnsIntegration(unittest.TestCase):
 
         account = self.client.get_or_create_account(
             email_address=test_email,
+            app_password=None,
             display_name='OAuth Test User',
             auth_method='oauth',
             oauth_refresh_token='test_refresh_token_value'
@@ -223,6 +226,8 @@ class TestEmailAccountOAuthColumnsIntegration(unittest.TestCase):
         # Create account first
         self.client.get_or_create_account(
             email_address=test_email,
+            app_password=None,
+            oauth_refresh_token=None,
             display_name='OAuth Update Test',
             auth_method='imap'
         )
@@ -254,6 +259,8 @@ class TestEmailAccountOAuthColumnsIntegration(unittest.TestCase):
         # Create account with OAuth
         self.client.get_or_create_account(
             email_address=test_email,
+            display_name=None,
+            app_password=None,
             auth_method='oauth',
             oauth_refresh_token='test_refresh'
         )

--- a/tests/test_emails_reviewed_count_integration.py
+++ b/tests/test_emails_reviewed_count_integration.py
@@ -111,7 +111,7 @@ class TestEmailsReviewedCountIntegration(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings
@@ -148,7 +148,7 @@ class TestEmailsReviewedCountIntegration(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings
@@ -186,7 +186,7 @@ class TestEmailsReviewedCountIntegration(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings
@@ -285,7 +285,7 @@ class TestEmailsReviewedCountEndToEnd(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings

--- a/tests/test_emails_reviewed_count_integration.py
+++ b/tests/test_emails_reviewed_count_integration.py
@@ -111,7 +111,7 @@ class TestEmailsReviewedCountIntegration(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings
@@ -148,7 +148,7 @@ class TestEmailsReviewedCountIntegration(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings
@@ -186,7 +186,7 @@ class TestEmailsReviewedCountIntegration(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings
@@ -285,7 +285,7 @@ class TestEmailsReviewedCountEndToEnd(unittest.TestCase):
         """
         # Setup account
         test_email = self.fake.email()
-        account = self.fake_account_category_client.get_or_create_account(test_email)
+        account = self.fake_account_category_client.get_or_create_account(test_email, None, None, None)
         account.app_password = self.fake.password(length=16)
 
         # Setup settings

--- a/tests/test_fake_account_category_client.py
+++ b/tests/test_fake_account_category_client.py
@@ -17,7 +17,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
 
     def test_get_or_create_account_creates_new(self):
         """Test creating a new account."""
-        account = self.client.get_or_create_account(self.test_email, self.test_display_name, None, None)
+        account = self.client.get_or_create_account(self.test_email, self.test_display_name, None, None, None)
 
         self.assertIsInstance(account, FakeEmailAccount)
         self.assertEqual(account.email_address, self.test_email)
@@ -28,10 +28,10 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_or_create_account_returns_existing(self):
         """Test that get_or_create returns existing account."""
         # Create account
-        account1 = self.client.get_or_create_account(self.test_email, self.test_display_name, None, None)
+        account1 = self.client.get_or_create_account(self.test_email, self.test_display_name, None, None, None)
 
         # Get the same account
-        account2 = self.client.get_or_create_account(self.test_email, "Different Name", None, None)
+        account2 = self.client.get_or_create_account(self.test_email, "Different Name", None, None, None)
 
         # Should be the same account
         self.assertEqual(account1.id, account2.id)

--- a/tests/test_fake_account_category_client.py
+++ b/tests/test_fake_account_category_client.py
@@ -42,15 +42,15 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_or_create_account_invalid_email(self):
         """Test that invalid email raises ValueError."""
         with self.assertRaises(ValueError):
-            self.client.get_or_create_account("", None, None, None)
+            self.client.get_or_create_account("", None, None, None, None)
 
         with self.assertRaises(ValueError):
-            self.client.get_or_create_account("   ", None, None, None)
+            self.client.get_or_create_account("   ", None, None, None, None)
 
     def test_get_account_by_email_found(self):
         """Test retrieving an existing account."""
         # Create account
-        created = self.client.get_or_create_account(self.test_email, None, None, None)
+        created = self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         # Retrieve it
         retrieved = self.client.get_account_by_email(self.test_email)
@@ -72,7 +72,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_update_account_last_scan(self):
         """Test updating last scan timestamp."""
         # Create account
-        account = self.client.get_or_create_account(self.test_email, None, None, None)
+        account = self.client.get_or_create_account(self.test_email, None, None, None, None)
         self.assertIsNone(account.last_scan_at)
 
         # Update last scan
@@ -91,7 +91,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_record_category_stats(self):
         """Test recording category statistics."""
         # Create account first
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         # Record stats
         stats_date = date.today()
@@ -114,7 +114,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_top_categories(self):
         """Test retrieving top categories."""
         # Create account
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         # Record some stats
         stats_date = date.today()
@@ -144,7 +144,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_top_categories_with_counts(self):
         """Test retrieving top categories with detailed counts."""
         # Create account
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         # Record some stats
         category_stats = {
@@ -171,7 +171,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_top_categories_limit(self):
         """Test that limit parameter works correctly."""
         # Create account
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         # Record stats for 5 categories
         category_stats = {
@@ -194,7 +194,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
 
     def test_get_top_categories_invalid_days(self):
         """Test that invalid days parameter raises ValueError."""
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         with self.assertRaises(ValueError):
             self.client.get_top_categories(self.test_email, days=0)
@@ -204,7 +204,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
 
     def test_get_top_categories_invalid_limit(self):
         """Test that invalid limit parameter raises ValueError."""
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         with self.assertRaises(ValueError):
             self.client.get_top_categories(self.test_email, days=30, limit=0)
@@ -220,9 +220,9 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_all_accounts_with_data(self):
         """Test getting all accounts."""
         # Create multiple accounts
-        self.client.get_or_create_account("user1@example.com", None, None, None)
-        self.client.get_or_create_account("user2@example.com", None, None, None)
-        self.client.get_or_create_account("user3@example.com", None, None, None)
+        self.client.get_or_create_account("user1@example.com", None, None, None, None)
+        self.client.get_or_create_account("user2@example.com", None, None, None, None)
+        self.client.get_or_create_account("user3@example.com", None, None, None, None)
 
         accounts = self.client.get_all_accounts(active_only=True)
         self.assertEqual(len(accounts), 3)
@@ -230,8 +230,8 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_all_accounts_active_only(self):
         """Test filtering accounts by active status."""
         # Create accounts
-        self.client.get_or_create_account("user1@example.com", None, None, None)
-        self.client.get_or_create_account("user2@example.com", None, None, None)
+        self.client.get_or_create_account("user1@example.com", None, None, None, None)
+        self.client.get_or_create_account("user2@example.com", None, None, None, None)
 
         # Deactivate one
         self.client.deactivate_account("user1@example.com")
@@ -248,7 +248,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_deactivate_account(self):
         """Test deactivating an account."""
         # Create account
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         # Deactivate it
         result = self.client.deactivate_account(self.test_email)
@@ -271,7 +271,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_email_case_insensitive(self):
         """Test that email addresses are case-insensitive."""
         # Create account with uppercase
-        account1 = self.client.get_or_create_account("Test@Example.COM", None, None, None)
+        account1 = self.client.get_or_create_account("Test@Example.COM", None, None, None, None)
 
         # Retrieve with lowercase
         account2 = self.client.get_account_by_email("test@example.com")
@@ -282,7 +282,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_record_category_stats_integer_format(self):
         """Test recording category stats with integer counts (simplified format)."""
         # Create account
-        self.client.get_or_create_account(self.test_email, None, None, None)
+        self.client.get_or_create_account(self.test_email, None, None, None, None)
 
         # Record stats with integer format
         category_stats = {

--- a/tests/test_fake_account_category_client.py
+++ b/tests/test_fake_account_category_client.py
@@ -17,7 +17,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
 
     def test_get_or_create_account_creates_new(self):
         """Test creating a new account."""
-        account = self.client.get_or_create_account(self.test_email, self.test_display_name)
+        account = self.client.get_or_create_account(self.test_email, self.test_display_name, None, None)
 
         self.assertIsInstance(account, FakeEmailAccount)
         self.assertEqual(account.email_address, self.test_email)
@@ -28,10 +28,10 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_or_create_account_returns_existing(self):
         """Test that get_or_create returns existing account."""
         # Create account
-        account1 = self.client.get_or_create_account(self.test_email, self.test_display_name)
+        account1 = self.client.get_or_create_account(self.test_email, self.test_display_name, None, None)
 
         # Get the same account
-        account2 = self.client.get_or_create_account(self.test_email, "Different Name")
+        account2 = self.client.get_or_create_account(self.test_email, "Different Name", None, None)
 
         # Should be the same account
         self.assertEqual(account1.id, account2.id)
@@ -42,15 +42,15 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_or_create_account_invalid_email(self):
         """Test that invalid email raises ValueError."""
         with self.assertRaises(ValueError):
-            self.client.get_or_create_account("")
+            self.client.get_or_create_account("", None, None, None)
 
         with self.assertRaises(ValueError):
-            self.client.get_or_create_account("   ")
+            self.client.get_or_create_account("   ", None, None, None)
 
     def test_get_account_by_email_found(self):
         """Test retrieving an existing account."""
         # Create account
-        created = self.client.get_or_create_account(self.test_email)
+        created = self.client.get_or_create_account(self.test_email, None, None, None)
 
         # Retrieve it
         retrieved = self.client.get_account_by_email(self.test_email)
@@ -72,7 +72,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_update_account_last_scan(self):
         """Test updating last scan timestamp."""
         # Create account
-        account = self.client.get_or_create_account(self.test_email)
+        account = self.client.get_or_create_account(self.test_email, None, None, None)
         self.assertIsNone(account.last_scan_at)
 
         # Update last scan
@@ -91,7 +91,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_record_category_stats(self):
         """Test recording category statistics."""
         # Create account first
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         # Record stats
         stats_date = date.today()
@@ -114,7 +114,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_top_categories(self):
         """Test retrieving top categories."""
         # Create account
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         # Record some stats
         stats_date = date.today()
@@ -144,7 +144,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_top_categories_with_counts(self):
         """Test retrieving top categories with detailed counts."""
         # Create account
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         # Record some stats
         category_stats = {
@@ -171,7 +171,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_get_top_categories_limit(self):
         """Test that limit parameter works correctly."""
         # Create account
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         # Record stats for 5 categories
         category_stats = {
@@ -194,7 +194,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
 
     def test_get_top_categories_invalid_days(self):
         """Test that invalid days parameter raises ValueError."""
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         with self.assertRaises(ValueError):
             self.client.get_top_categories(self.test_email, days=0)
@@ -204,7 +204,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
 
     def test_get_top_categories_invalid_limit(self):
         """Test that invalid limit parameter raises ValueError."""
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         with self.assertRaises(ValueError):
             self.client.get_top_categories(self.test_email, days=30, limit=0)
@@ -214,24 +214,24 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
 
     def test_get_all_accounts_empty(self):
         """Test getting all accounts when none exist."""
-        accounts = self.client.get_all_accounts()
+        accounts = self.client.get_all_accounts(active_only=True)
         self.assertEqual(len(accounts), 0)
 
     def test_get_all_accounts_with_data(self):
         """Test getting all accounts."""
         # Create multiple accounts
-        self.client.get_or_create_account("user1@example.com")
-        self.client.get_or_create_account("user2@example.com")
-        self.client.get_or_create_account("user3@example.com")
+        self.client.get_or_create_account("user1@example.com", None, None, None)
+        self.client.get_or_create_account("user2@example.com", None, None, None)
+        self.client.get_or_create_account("user3@example.com", None, None, None)
 
-        accounts = self.client.get_all_accounts()
+        accounts = self.client.get_all_accounts(active_only=True)
         self.assertEqual(len(accounts), 3)
 
     def test_get_all_accounts_active_only(self):
         """Test filtering accounts by active status."""
         # Create accounts
-        self.client.get_or_create_account("user1@example.com")
-        self.client.get_or_create_account("user2@example.com")
+        self.client.get_or_create_account("user1@example.com", None, None, None)
+        self.client.get_or_create_account("user2@example.com", None, None, None)
 
         # Deactivate one
         self.client.deactivate_account("user1@example.com")
@@ -248,7 +248,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_deactivate_account(self):
         """Test deactivating an account."""
         # Create account
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         # Deactivate it
         result = self.client.deactivate_account(self.test_email)
@@ -271,7 +271,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_email_case_insensitive(self):
         """Test that email addresses are case-insensitive."""
         # Create account with uppercase
-        account1 = self.client.get_or_create_account("Test@Example.COM")
+        account1 = self.client.get_or_create_account("Test@Example.COM", None, None, None)
 
         # Retrieve with lowercase
         account2 = self.client.get_account_by_email("test@example.com")
@@ -282,7 +282,7 @@ class TestFakeAccountCategoryClient(unittest.TestCase):
     def test_record_category_stats_integer_format(self):
         """Test recording category stats with integer counts (simplified format)."""
         # Create account
-        self.client.get_or_create_account(self.test_email)
+        self.client.get_or_create_account(self.test_email, None, None, None)
 
         # Record stats with integer format
         category_stats = {

--- a/tests/test_oauth_status_badge.py
+++ b/tests/test_oauth_status_badge.py
@@ -1,0 +1,877 @@
+"""
+Test suite for OAuth Status Badge feature on Accounts Page.
+
+These tests verify that the /api/accounts endpoint includes auth_method field
+for each account, enabling the frontend to display appropriate OAuth/IMAP badges.
+
+Based on BDD Gherkin scenarios from tests/bdd/oauth-status-badge.feature
+
+TDD Red Phase: These tests are expected to FAIL until implementation is complete.
+The coder agent should:
+1. Add auth_method field to EmailAccountInfo model
+2. Update /api/accounts endpoint to include auth_method in response
+3. Update FakeAccountCategoryClient to support auth_method
+"""
+import pytest
+from datetime import datetime
+from typing import Optional
+from unittest.mock import Mock, MagicMock, patch
+from dataclasses import dataclass, field
+
+import sys
+import os
+
+# Add parent directory to path to import API modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Set required environment variables before importing api_service
+os.environ.setdefault('REQUESTYAI_API_KEY', 'test-key-for-unit-tests')
+
+
+# ============================================================================
+# Test Fixtures and Helpers
+# ============================================================================
+
+@dataclass
+class MockEmailAccount:
+    """Mock email account for testing auth_method behavior."""
+    id: int
+    email_address: str
+    display_name: str
+    is_active: bool = True
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    last_scan_at: Optional[datetime] = None
+    app_password: Optional[str] = None
+    auth_method: Optional[str] = None
+
+
+class MockAccountService:
+    """Mock account service that returns accounts with auth_method."""
+
+    def __init__(self):
+        self.accounts = {}
+        self._next_id = 1
+
+    def add_account(
+        self,
+        email_address: str,
+        auth_method: Optional[str],
+        app_password: Optional[str]
+    ) -> MockEmailAccount:
+        """Add a mock account with specified auth_method."""
+        account = MockEmailAccount(
+            id=self._next_id,
+            email_address=email_address,
+            display_name=email_address,
+            auth_method=auth_method,
+            app_password=app_password
+        )
+        self._next_id += 1
+        self.accounts[email_address] = account
+        return account
+
+    def get_all_accounts(self, active_only: bool) -> list:
+        """Return all accounts."""
+        accounts = list(self.accounts.values())
+        if active_only:
+            accounts = [acc for acc in accounts if acc.is_active]
+        return accounts
+
+    def get_account_by_email(self, email_address: str) -> Optional[MockEmailAccount]:
+        """Get account by email."""
+        return self.accounts.get(email_address.lower())
+
+
+# ============================================================================
+# HAPPY PATH TESTS - API Response Behavior
+# ============================================================================
+
+class TestApiResponseIncludesAuthMethod:
+    """
+    Tests that the API response includes auth_method field for each account.
+
+    Corresponds to BDD scenarios:
+    - API response includes auth_method for each account
+    - OAuth account returns oauth auth_method in API response
+    - IMAP account returns imap auth_method in API response
+    - Legacy account returns null auth_method in API response
+    """
+
+    def test_api_response_includes_auth_method_for_each_account(self):
+        """
+        Test that each account in the API response includes an auth_method field.
+
+        The implementation should:
+        - Add auth_method to EmailAccountInfo model
+        - Include auth_method when converting database accounts to response format
+
+        BDD Scenario: API response includes auth_method for each account
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        mock_service.add_account("oauth@gmail.com", "oauth", None)
+        mock_service.add_account("imap@company.com", "imap", "password123")
+        mock_service.add_account("legacy@gmail.com", None, "oldpass")
+
+        # Act - Get accounts from service
+        accounts = mock_service.get_all_accounts(active_only=True)
+
+        # Assert - Each account should have auth_method attribute
+        for account in accounts:
+            assert hasattr(account, 'auth_method'), \
+                f"Account {account.email_address} missing auth_method attribute"
+
+    def test_oauth_account_returns_oauth_auth_method_in_api_response(self):
+        """
+        Test that an OAuth-configured account returns auth_method="oauth".
+
+        The implementation should:
+        - Return auth_method "oauth" for accounts configured with OAuth
+
+        BDD Scenario: OAuth account returns oauth auth_method in API response
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        mock_service.add_account("user@gmail.com", "oauth", None)
+
+        # Act
+        account = mock_service.get_account_by_email("user@gmail.com")
+
+        # Assert
+        assert account is not None, "Account should exist"
+        assert account.auth_method == "oauth", \
+            f"Expected auth_method 'oauth', got '{account.auth_method}'"
+
+    def test_imap_account_returns_imap_auth_method_in_api_response(self):
+        """
+        Test that an IMAP-configured account returns auth_method="imap".
+
+        The implementation should:
+        - Return auth_method "imap" for accounts configured with IMAP credentials
+
+        BDD Scenario: IMAP account returns imap auth_method in API response
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        mock_service.add_account("user@company.com", "imap", "app_password_123")
+
+        # Act
+        account = mock_service.get_account_by_email("user@company.com")
+
+        # Assert
+        assert account is not None, "Account should exist"
+        assert account.auth_method == "imap", \
+            f"Expected auth_method 'imap', got '{account.auth_method}'"
+
+    def test_legacy_account_returns_null_auth_method_in_api_response(self):
+        """
+        Test that a legacy account (created before auth_method tracking) returns null.
+
+        The implementation should:
+        - Return auth_method null for accounts without auth_method set
+
+        BDD Scenario: Legacy account returns null auth_method in API response
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        mock_service.add_account("legacy@gmail.com", None, "old_password")
+
+        # Act
+        account = mock_service.get_account_by_email("legacy@gmail.com")
+
+        # Assert
+        assert account is not None, "Account should exist"
+        assert account.auth_method is None, \
+            f"Expected auth_method None, got '{account.auth_method}'"
+
+
+class TestEmailAccountInfoModelAuthMethod:
+    """
+    Tests that EmailAccountInfo Pydantic model includes auth_method field.
+
+    The implementation should add:
+    - auth_method: Optional[str] field to EmailAccountInfo model
+    """
+
+    def test_email_account_info_model_has_auth_method_field(self):
+        """
+        Test that EmailAccountInfo model includes auth_method field.
+
+        The implementation should:
+        - Add auth_method as Optional[str] to EmailAccountInfo
+        - Field should be nullable (Optional)
+        """
+        from models.account_models import EmailAccountInfo
+
+        # Arrange & Act - Create instance with auth_method
+        account_info = EmailAccountInfo(
+            id=1,
+            email_address="test@gmail.com",
+            auth_method="oauth",
+            created_at=datetime.now()
+        )
+
+        # Assert
+        assert hasattr(account_info, 'auth_method'), \
+            "EmailAccountInfo should have auth_method attribute"
+        assert account_info.auth_method == "oauth", \
+            f"Expected auth_method 'oauth', got '{account_info.auth_method}'"
+
+    def test_email_account_info_auth_method_can_be_null(self):
+        """
+        Test that auth_method can be null for legacy accounts.
+
+        The implementation should:
+        - Allow auth_method to be None (for legacy accounts)
+        """
+        from models.account_models import EmailAccountInfo
+
+        # Arrange & Act - Create instance with null auth_method
+        account_info = EmailAccountInfo(
+            id=1,
+            email_address="legacy@gmail.com",
+            auth_method=None,
+            created_at=datetime.now()
+        )
+
+        # Assert
+        assert account_info.auth_method is None, \
+            "auth_method should be None for legacy accounts"
+
+    def test_email_account_info_auth_method_in_dict_representation(self):
+        """
+        Test that auth_method appears in dict/JSON representation.
+
+        The implementation should:
+        - Include auth_method in model_dump() / dict() output
+        """
+        from models.account_models import EmailAccountInfo
+
+        # Arrange
+        account_info = EmailAccountInfo(
+            id=1,
+            email_address="test@gmail.com",
+            auth_method="imap",
+            created_at=datetime.now()
+        )
+
+        # Act - Get dict representation
+        # Note: Pydantic v2 uses model_dump(), v1 uses dict()
+        try:
+            account_dict = account_info.model_dump()
+        except AttributeError:
+            account_dict = account_info.dict()
+
+        # Assert
+        assert "auth_method" in account_dict, \
+            "auth_method should be in dict representation"
+        assert account_dict["auth_method"] == "imap", \
+            f"Expected auth_method 'imap', got '{account_dict['auth_method']}'"
+
+    def test_email_account_info_accepts_oauth_value(self):
+        """
+        Test that EmailAccountInfo accepts 'oauth' as auth_method value.
+        """
+        from models.account_models import EmailAccountInfo
+
+        # Arrange & Act
+        account_info = EmailAccountInfo(
+            id=1,
+            email_address="oauth@gmail.com",
+            auth_method="oauth",
+            created_at=datetime.now()
+        )
+
+        # Assert
+        assert account_info.auth_method == "oauth"
+
+    def test_email_account_info_accepts_imap_value(self):
+        """
+        Test that EmailAccountInfo accepts 'imap' as auth_method value.
+        """
+        from models.account_models import EmailAccountInfo
+
+        # Arrange & Act
+        account_info = EmailAccountInfo(
+            id=1,
+            email_address="imap@company.com",
+            auth_method="imap",
+            created_at=datetime.now()
+        )
+
+        # Assert
+        assert account_info.auth_method == "imap"
+
+
+# ============================================================================
+# EDGE CASE TESTS
+# ============================================================================
+
+class TestAuthMethodEdgeCases:
+    """
+    Tests for edge cases in auth_method handling.
+
+    Corresponds to BDD scenarios:
+    - Legacy account with null auth_method displays Not Configured badge
+    - Case insensitive auth_method handling
+    - Badge renders gracefully for unexpected auth_method value
+    - Badge renders when auth_method field is missing from response
+    """
+
+    def test_null_auth_method_for_legacy_account(self):
+        """
+        Test that legacy accounts (before auth_method tracking) have null auth_method.
+
+        BDD Scenario: Legacy account with null auth_method displays Not Configured badge
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        mock_service.add_account("legacy@gmail.com", None, "old_password")
+
+        # Act
+        account = mock_service.get_account_by_email("legacy@gmail.com")
+
+        # Assert
+        assert account.auth_method is None, \
+            "Legacy account should have null auth_method"
+
+    def test_case_insensitive_auth_method_handling_uppercase_oauth(self):
+        """
+        Test case insensitive handling of auth_method (OAuth vs oauth).
+
+        The implementation should normalize auth_method values.
+
+        BDD Scenario: Case insensitive auth_method handling
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        # Simulate database returning uppercase
+        account = mock_service.add_account("user@gmail.com", "OAuth", None)
+
+        # Act & Assert
+        # The implementation should normalize to lowercase
+        normalized = account.auth_method.lower() if account.auth_method else None
+        assert normalized == "oauth", \
+            "auth_method should be handled case-insensitively"
+
+    def test_case_insensitive_auth_method_handling_uppercase_imap(self):
+        """
+        Test case insensitive handling of auth_method (IMAP vs imap).
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        account = mock_service.add_account("user@company.com", "IMAP", "password")
+
+        # Act & Assert
+        normalized = account.auth_method.lower() if account.auth_method else None
+        assert normalized == "imap", \
+            "auth_method should be handled case-insensitively"
+
+    def test_unexpected_auth_method_value_treated_as_not_configured(self):
+        """
+        Test that unexpected auth_method values are handled gracefully.
+
+        The frontend should display "Not Configured" for unexpected values.
+
+        BDD Scenario: Badge renders gracefully for unexpected auth_method value
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        account = mock_service.add_account("user@gmail.com", "unexpected_value", None)
+
+        # Act & Assert
+        # The backend should allow any string, but frontend will handle display
+        assert account.auth_method == "unexpected_value", \
+            "Backend should store the value as-is"
+        # Frontend will interpret non-oauth/non-imap as "Not Configured"
+        valid_methods = {"oauth", "imap"}
+        is_valid = account.auth_method.lower() in valid_methods if account.auth_method else False
+        assert not is_valid, \
+            "unexpected_value should not be a valid auth method"
+
+
+class TestAccountsListMixedAuthMethods:
+    """
+    Tests for displaying mixed authentication methods in accounts list.
+
+    Corresponds to BDD scenario:
+    - Accounts list shows mixed authentication methods
+    """
+
+    def test_accounts_list_shows_mixed_authentication_methods(self):
+        """
+        Test that accounts list correctly shows mixed OAuth and IMAP accounts.
+
+        BDD Scenario: Accounts list shows mixed authentication methods
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        mock_service.add_account("oauth1@gmail.com", "oauth", None)
+        mock_service.add_account("imap1@company.com", "imap", "password123")
+        mock_service.add_account("oauth2@gmail.com", "oauth", None)
+
+        # Act
+        accounts = mock_service.get_all_accounts(active_only=True)
+        accounts_by_email = {acc.email_address: acc for acc in accounts}
+
+        # Assert
+        assert len(accounts) == 3, f"Expected 3 accounts, got {len(accounts)}"
+
+        assert accounts_by_email["oauth1@gmail.com"].auth_method == "oauth", \
+            "oauth1@gmail.com should have auth_method 'oauth'"
+        assert accounts_by_email["imap1@company.com"].auth_method == "imap", \
+            "imap1@company.com should have auth_method 'imap'"
+        assert accounts_by_email["oauth2@gmail.com"].auth_method == "oauth", \
+            "oauth2@gmail.com should have auth_method 'oauth'"
+
+
+class TestEmptyAccountsList:
+    """
+    Tests for empty accounts list behavior.
+
+    Corresponds to BDD scenario:
+    - Empty accounts list renders correctly
+    """
+
+    def test_empty_accounts_list_returns_empty_array(self):
+        """
+        Test that empty accounts list returns empty array with auth_method support.
+
+        BDD Scenario: Empty accounts list renders correctly
+        """
+        # Arrange
+        mock_service = MockAccountService()
+        # No accounts added
+
+        # Act
+        accounts = mock_service.get_all_accounts(active_only=True)
+
+        # Assert
+        assert accounts == [], "Empty accounts list should return empty array"
+
+
+# ============================================================================
+# API ENDPOINT INTEGRATION TESTS
+# ============================================================================
+
+class TestAccountsEndpointAuthMethod:
+    """
+    Tests for /api/accounts endpoint auth_method field inclusion.
+
+    These tests verify the actual API endpoint returns auth_method.
+    """
+
+    def test_accounts_endpoint_includes_auth_method_field(self):
+        """
+        Test that /api/accounts endpoint includes auth_method for each account.
+
+        The implementation should:
+        - Modify get_all_accounts endpoint to include auth_method in response
+        - Map database auth_method to EmailAccountInfo.auth_method
+        """
+        # Mock SettingsService to prevent MySQL initialization
+        with patch('services.settings_service.SettingsService') as mock_settings:
+            mock_settings_instance = MagicMock()
+            mock_settings.return_value = mock_settings_instance
+
+            from fastapi.testclient import TestClient
+            from api_service import app, get_account_service
+
+            # Create test client
+            client = TestClient(app)
+
+            # Create mock service with accounts having different auth methods
+            mock_service = MockAccountService()
+            mock_service.add_account("oauth@gmail.com", "oauth", None)
+            mock_service.add_account("imap@company.com", "imap", "password123")
+            mock_service.add_account("legacy@gmail.com", None, "oldpass")
+
+            # Override dependency
+            app.dependency_overrides[get_account_service] = lambda: mock_service
+
+            # Set API key for authentication
+            os.environ['API_KEY'] = 'test-api-key'
+            headers = {"X-API-Key": "test-api-key"}
+
+            try:
+                # Act
+                response = client.get("/api/accounts", headers=headers)
+
+                # Assert
+                assert response.status_code == 200, \
+                    f"Expected 200, got {response.status_code}: {response.text}"
+
+                data = response.json()
+                assert "accounts" in data, "Response should contain 'accounts' field"
+
+                # Each account should have auth_method field
+                for account in data["accounts"]:
+                    assert "auth_method" in account, \
+                        f"Account {account.get('email_address')} missing auth_method field"
+
+                # Verify specific values
+                accounts_by_email = {acc["email_address"]: acc for acc in data["accounts"]}
+
+                oauth_account = accounts_by_email.get("oauth@gmail.com")
+                assert oauth_account is not None, "oauth@gmail.com should exist"
+                assert oauth_account["auth_method"] == "oauth", \
+                    f"Expected 'oauth', got '{oauth_account['auth_method']}'"
+
+                imap_account = accounts_by_email.get("imap@company.com")
+                assert imap_account is not None, "imap@company.com should exist"
+                assert imap_account["auth_method"] == "imap", \
+                    f"Expected 'imap', got '{imap_account['auth_method']}'"
+
+                legacy_account = accounts_by_email.get("legacy@gmail.com")
+                assert legacy_account is not None, "legacy@gmail.com should exist"
+                assert legacy_account["auth_method"] is None, \
+                    f"Expected None, got '{legacy_account['auth_method']}'"
+
+            finally:
+                # Cleanup
+                app.dependency_overrides.clear()
+                if 'API_KEY' in os.environ:
+                    del os.environ['API_KEY']
+
+    def test_accounts_endpoint_returns_complete_response_with_auth_method(self):
+        """
+        Test that the complete API response includes all required fields including auth_method.
+
+        Per testing-standards.md: Assert complete response structures, not individual fields.
+        """
+        with patch('services.settings_service.SettingsService') as mock_settings:
+            mock_settings_instance = MagicMock()
+            mock_settings.return_value = mock_settings_instance
+
+            from fastapi.testclient import TestClient
+            from api_service import app, get_account_service
+
+            client = TestClient(app)
+
+            # Create single account for predictable testing
+            mock_service = MockAccountService()
+            test_account = mock_service.add_account("test@gmail.com", "oauth", None)
+
+            app.dependency_overrides[get_account_service] = lambda: mock_service
+            os.environ['API_KEY'] = 'test-api-key'
+            headers = {"X-API-Key": "test-api-key"}
+
+            try:
+                response = client.get("/api/accounts", headers=headers)
+
+                assert response.status_code == 200
+                data = response.json()
+
+                # Verify response structure
+                assert "accounts" in data
+                assert "total_count" in data
+                assert data["total_count"] == 1
+
+                # Verify account has all required fields including auth_method
+                account = data["accounts"][0]
+                required_fields = [
+                    "id",
+                    "email_address",
+                    "is_active",
+                    "created_at",
+                    "auth_method"  # New required field
+                ]
+
+                for field_name in required_fields:
+                    assert field_name in account, \
+                        f"Account missing required field: {field_name}"
+
+            finally:
+                app.dependency_overrides.clear()
+                if 'API_KEY' in os.environ:
+                    del os.environ['API_KEY']
+
+
+# ============================================================================
+# BADGE DISPLAY LOGIC TESTS (Frontend Support)
+# ============================================================================
+
+class TestBadgeDisplayLogic:
+    """
+    Tests for badge display logic based on auth_method values.
+
+    These tests verify the logic for determining badge text and style.
+
+    Corresponds to BDD scenarios:
+    - OAuth Connected account displays green badge
+    - IMAP account displays gray badge
+    - Legacy account with null auth_method displays Not Configured badge
+    """
+
+    def test_oauth_auth_method_maps_to_oauth_connected_badge(self):
+        """
+        Test that auth_method="oauth" should display "OAuth Connected" badge.
+
+        BDD Scenario: OAuth Connected account displays green badge
+        """
+        # Arrange
+        auth_method = "oauth"
+
+        # Act - Badge display logic
+        if auth_method and auth_method.lower() == "oauth":
+            badge_text = "OAuth Connected"
+            badge_style = "green"
+        elif auth_method and auth_method.lower() == "imap":
+            badge_text = "IMAP"
+            badge_style = "gray"
+        else:
+            badge_text = "Not Configured"
+            badge_style = "neutral"
+
+        # Assert
+        assert badge_text == "OAuth Connected", \
+            f"Expected 'OAuth Connected', got '{badge_text}'"
+        assert badge_style == "green", \
+            f"Expected 'green', got '{badge_style}'"
+
+    def test_imap_auth_method_maps_to_imap_badge(self):
+        """
+        Test that auth_method="imap" should display "IMAP" badge.
+
+        BDD Scenario: IMAP account displays gray badge
+        """
+        # Arrange
+        auth_method = "imap"
+
+        # Act - Badge display logic
+        if auth_method and auth_method.lower() == "oauth":
+            badge_text = "OAuth Connected"
+            badge_style = "green"
+        elif auth_method and auth_method.lower() == "imap":
+            badge_text = "IMAP"
+            badge_style = "gray"
+        else:
+            badge_text = "Not Configured"
+            badge_style = "neutral"
+
+        # Assert
+        assert badge_text == "IMAP", \
+            f"Expected 'IMAP', got '{badge_text}'"
+        assert badge_style == "gray", \
+            f"Expected 'gray', got '{badge_style}'"
+
+    def test_null_auth_method_maps_to_not_configured_badge(self):
+        """
+        Test that auth_method=null should display "Not Configured" badge.
+
+        BDD Scenario: Legacy account with null auth_method displays Not Configured badge
+        """
+        # Arrange
+        auth_method = None
+
+        # Act - Badge display logic
+        if auth_method and auth_method.lower() == "oauth":
+            badge_text = "OAuth Connected"
+            badge_style = "green"
+        elif auth_method and auth_method.lower() == "imap":
+            badge_text = "IMAP"
+            badge_style = "gray"
+        else:
+            badge_text = "Not Configured"
+            badge_style = "neutral"
+
+        # Assert
+        assert badge_text == "Not Configured", \
+            f"Expected 'Not Configured', got '{badge_text}'"
+        assert badge_style == "neutral", \
+            f"Expected 'neutral', got '{badge_style}'"
+
+    def test_unexpected_auth_method_maps_to_not_configured_badge(self):
+        """
+        Test that unexpected auth_method values display "Not Configured" badge.
+
+        BDD Scenario: Badge renders gracefully for unexpected auth_method value
+        """
+        # Arrange
+        auth_method = "unexpected_value"
+
+        # Act - Badge display logic
+        if auth_method and auth_method.lower() == "oauth":
+            badge_text = "OAuth Connected"
+            badge_style = "green"
+        elif auth_method and auth_method.lower() == "imap":
+            badge_text = "IMAP"
+            badge_style = "gray"
+        else:
+            badge_text = "Not Configured"
+            badge_style = "neutral"
+
+        # Assert
+        assert badge_text == "Not Configured", \
+            f"Expected 'Not Configured', got '{badge_text}'"
+        assert badge_style == "neutral", \
+            f"Expected 'neutral', got '{badge_style}'"
+
+
+# ============================================================================
+# ACCESSIBILITY TESTS
+# ============================================================================
+
+class TestBadgeAccessibility:
+    """
+    Tests for badge accessibility attributes.
+
+    Corresponds to BDD scenarios:
+    - OAuth badge has accessible aria-label
+    - IMAP badge has accessible aria-label
+    - Not Configured badge has accessible aria-label
+    """
+
+    def test_oauth_badge_aria_label(self):
+        """
+        Test that OAuth badge has correct aria-label.
+
+        BDD Scenario: OAuth badge has accessible aria-label
+        """
+        # Arrange
+        auth_method = "oauth"
+
+        # Act - Compute aria-label
+        if auth_method and auth_method.lower() == "oauth":
+            badge_text = "OAuth Connected"
+        elif auth_method and auth_method.lower() == "imap":
+            badge_text = "IMAP"
+        else:
+            badge_text = "Not Configured"
+
+        aria_label = f"Authentication method: {badge_text}"
+
+        # Assert
+        expected_aria_label = "Authentication method: OAuth Connected"
+        assert aria_label == expected_aria_label, \
+            f"Expected '{expected_aria_label}', got '{aria_label}'"
+
+    def test_imap_badge_aria_label(self):
+        """
+        Test that IMAP badge has correct aria-label.
+
+        BDD Scenario: IMAP badge has accessible aria-label
+        """
+        # Arrange
+        auth_method = "imap"
+
+        # Act - Compute aria-label
+        if auth_method and auth_method.lower() == "oauth":
+            badge_text = "OAuth Connected"
+        elif auth_method and auth_method.lower() == "imap":
+            badge_text = "IMAP"
+        else:
+            badge_text = "Not Configured"
+
+        aria_label = f"Authentication method: {badge_text}"
+
+        # Assert
+        expected_aria_label = "Authentication method: IMAP"
+        assert aria_label == expected_aria_label, \
+            f"Expected '{expected_aria_label}', got '{aria_label}'"
+
+    def test_not_configured_badge_aria_label(self):
+        """
+        Test that Not Configured badge has correct aria-label.
+
+        BDD Scenario: Not Configured badge has accessible aria-label
+        """
+        # Arrange
+        auth_method = None
+
+        # Act - Compute aria-label
+        if auth_method and auth_method.lower() == "oauth":
+            badge_text = "OAuth Connected"
+        elif auth_method and auth_method.lower() == "imap":
+            badge_text = "IMAP"
+        else:
+            badge_text = "Not Configured"
+
+        aria_label = f"Authentication method: {badge_text}"
+
+        # Assert
+        expected_aria_label = "Authentication method: Not Configured"
+        assert aria_label == expected_aria_label, \
+            f"Expected '{expected_aria_label}', got '{aria_label}'"
+
+
+# ============================================================================
+# FAKE ACCOUNT CATEGORY CLIENT TESTS
+# ============================================================================
+
+class TestFakeAccountCategoryClientAuthMethod:
+    """
+    Tests that FakeAccountCategoryClient supports auth_method.
+
+    The implementation should:
+    - Add auth_method field to FakeEmailAccount dataclass
+    - Support auth_method in get_or_create_account method
+    """
+
+    def test_fake_email_account_has_auth_method_attribute(self):
+        """
+        Test that FakeEmailAccount supports auth_method attribute.
+        """
+        from tests.fake_account_category_client import FakeEmailAccount
+
+        # Arrange & Act
+        account = FakeEmailAccount(
+            id=1,
+            email_address="test@gmail.com",
+            display_name="Test",
+            auth_method="oauth"
+        )
+
+        # Assert
+        assert hasattr(account, 'auth_method'), \
+            "FakeEmailAccount should have auth_method attribute"
+        assert account.auth_method == "oauth", \
+            f"Expected 'oauth', got '{account.auth_method}'"
+
+    def test_fake_client_get_or_create_account_supports_auth_method(self):
+        """
+        Test that FakeAccountCategoryClient.get_or_create_account supports auth_method.
+        """
+        from tests.fake_account_category_client import FakeAccountCategoryClient
+
+        # Arrange
+        client = FakeAccountCategoryClient()
+
+        # Act - Create account with auth_method parameter
+        account = client.get_or_create_account(
+            email_address="test@gmail.com",
+            display_name="Test",
+            app_password=None,
+            auth_method="oauth"  # New parameter
+        )
+
+        # Assert
+        assert account.auth_method == "oauth", \
+            f"Expected auth_method 'oauth', got '{account.auth_method}'"
+
+    def test_fake_client_returns_auth_method_in_get_all_accounts(self):
+        """
+        Test that get_all_accounts returns accounts with auth_method.
+        """
+        from tests.fake_account_category_client import FakeAccountCategoryClient
+
+        # Arrange
+        client = FakeAccountCategoryClient()
+        client.get_or_create_account("oauth@gmail.com", None, None, "oauth")
+        client.get_or_create_account("imap@gmail.com", None, None, "imap")
+
+        # Act
+        accounts = client.get_all_accounts(active_only=True)
+
+        # Assert
+        for account in accounts:
+            assert hasattr(account, 'auth_method'), \
+                f"Account {account.email_address} missing auth_method"
+
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/unit/test_process_account_integration.py
+++ b/tests/unit/test_process_account_integration.py
@@ -216,7 +216,7 @@ class TestCollectorClearedAtStartOfProcessing(unittest.TestCase):
         )
 
         # Setup account
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -268,7 +268,7 @@ class TestCollectorClearedAtStartOfProcessing(unittest.TestCase):
         )
 
         # Setup account with no emails
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -384,7 +384,7 @@ class TestDomainCollectionDuringProcessing(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -435,7 +435,7 @@ class TestDomainCollectionDuringProcessing(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -589,7 +589,7 @@ class TestMultipleDomainsWithDifferentCategories(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -669,7 +669,7 @@ class TestMultipleDomainsWithDifferentCategories(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -739,7 +739,7 @@ class TestMultipleDomainsWithDifferentCategories(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -840,7 +840,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -901,7 +901,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -962,7 +962,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1023,7 +1023,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1083,7 +1083,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1184,7 +1184,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1238,7 +1238,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1292,7 +1292,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1347,7 +1347,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1442,7 +1442,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1483,7 +1483,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1523,7 +1523,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1563,7 +1563,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1603,7 +1603,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1643,7 +1643,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1727,7 +1727,7 @@ class TestNoRecommendationsWhenInboxEmpty(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1781,7 +1781,7 @@ class TestNoRecommendationsWhenInboxEmpty(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1833,7 +1833,7 @@ class TestNoRecommendationsWhenInboxEmpty(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1923,7 +1923,7 @@ class TestNotificationEmailSubject(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -2017,7 +2017,7 @@ class TestCompleteResponseStructure(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act

--- a/tests/unit/test_process_account_integration.py
+++ b/tests/unit/test_process_account_integration.py
@@ -216,7 +216,7 @@ class TestCollectorClearedAtStartOfProcessing(unittest.TestCase):
         )
 
         # Setup account
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -268,7 +268,7 @@ class TestCollectorClearedAtStartOfProcessing(unittest.TestCase):
         )
 
         # Setup account with no emails
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -384,7 +384,7 @@ class TestDomainCollectionDuringProcessing(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -435,7 +435,7 @@ class TestDomainCollectionDuringProcessing(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -589,7 +589,7 @@ class TestMultipleDomainsWithDifferentCategories(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -669,7 +669,7 @@ class TestMultipleDomainsWithDifferentCategories(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -739,7 +739,7 @@ class TestMultipleDomainsWithDifferentCategories(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -840,7 +840,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -901,7 +901,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -962,7 +962,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1023,7 +1023,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1083,7 +1083,7 @@ class TestResponseIncludesRecommendationSummary(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1184,7 +1184,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1238,7 +1238,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1292,7 +1292,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1347,7 +1347,7 @@ class TestEmailNotificationFailureHandling(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1442,7 +1442,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1483,7 +1483,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1523,7 +1523,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1563,7 +1563,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1603,7 +1603,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1643,7 +1643,7 @@ class TestResponseMaintainsExistingFields(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         result = service.process_account(self.test_email)
@@ -1727,7 +1727,7 @@ class TestNoRecommendationsWhenInboxEmpty(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1781,7 +1781,7 @@ class TestNoRecommendationsWhenInboxEmpty(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1833,7 +1833,7 @@ class TestNoRecommendationsWhenInboxEmpty(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -1923,7 +1923,7 @@ class TestNotificationEmailSubject(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act
@@ -2017,7 +2017,7 @@ class TestCompleteResponseStructure(unittest.TestCase):
             create_gmail_fetcher=lambda email, pwd, token: fetcher
         )
 
-        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None)
+        account = self.account_category_client.get_or_create_account(self.test_email, None, None, None, None)
         account.app_password = "testpassword1234"
 
         # Act


### PR DESCRIPTION
## Summary
- Implement a visual indicator for authentication method (OAuth vs IMAP) directly on the Accounts page.
- Add an optional auth_method field to the account API response to support a single fetch for status data.
- Introduce an Auth Method column in the accounts table and render per-account badges indicating the authentication method (OAuth Connected for OAuth, IMAP for IMAP, Not Configured for unknown/null).
- Include a new draft spec and associated tests/docs to guide and verify the OAuth status badge design and data flow.

## Changes

### Backend / API
- Extend EmailAccountInfo API response model to include an optional auth_method field (e.g., 'oauth' or 'imap') so /api/accounts can render badges without extra API calls.
- Update GET /api/accounts response mapping to include account.auth_method.

### Frontend
- Add a new column "Auth Method" to the Accounts page table (placed after Email Address).
- Render a badge for each account based on account.auth_method:
  - oauth  -> green badge with text "OAuth Connected"
  - imap   -> gray badge with text "IMAP"
  - unknown/NULL -> neutral badge (e.g., "Not Configured")
- Implement badge rendering in accounts template and JavaScript rendering logic.
- Add CSS styles for the new badge variants and ensure accessibility attributes (aria-label) are present on badges.

### Data Model & Architecture
- EmailAccountInfo carries optional auth_method bound to the database's auth_method column.
- Frontend uses the new field to display the appropriate badge without extra API calls.

### Documentation & Specs
- Added a new draft spec: specs/DRAFT-oauth-status-badge.md outlining the OAuth status badge design and data flow.

### Files touched (high level)
- Backend: models/account_models.py (extend EmailAccountInfo with auth_method)
- Backend: api_service.py (include auth_method in GET /api/accounts response)
- Frontend: frontend/templates/accounts.html (add column and badge rendering)
- Specs: specs/DRAFT-oauth-status-badge.md (new draft spec)

## Testing plan
- API test: GET /api/accounts returns auth_method for each account (oauth, imap, unknown/NULL).
- Frontend/UI test: Accounts table includes a new Auth Method column with correct badges for various accounts.
- Edge cases: NULL or unknown auth_method shows a neutral/Not Configured badge; mixed accounts render appropriate badges in the same table.

### Manual test steps
1. Load the Accounts page and verify there is a new Auth Method column.
2. For accounts configured with OAuth, confirm the badge shows "OAuth Connected" with a green appearance.
3. For accounts using IMAP, confirm the badge shows "IMAP" with a gray appearance.
4. For accounts with NULL/unknown auth_method, confirm a neutral "Not Configured" badge is shown.
5. Ensure other columns and table layout remain correct.

## Notes
- This change relies on the existing auth_method column already present in the EmailAccount model.
- The implementation favors a single API call by including auth_method in the accounts response, avoiding per-account status calls.

## References / Task
- Task: https://www.terragonlabs.com/task/9a09bb6c-e7d7-4d92-b427-7cd48b79b1e8

---
Generated by the updated patch set and aligned with OAuth badge design and data flow expectations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accounts page adds an "Auth Method" column with badges: green "OAuth Connected", gray "IMAP", or "Not Configured".
* **Accessibility**
  * Badges and column header include aria attributes for screen readers.
* **Performance**
  * Accounts list loads more efficiently by returning auth method with account data to avoid redundant lookups.
* **Tests**
  * Added comprehensive tests covering badge display, API responses, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->