### PR TITLE
Add RestorationError and UTC-aware timestamps; graceful Gmail tests

### DIFF
--- a/services/oauth_account_restoration_service.py
+++ b/services/oauth_account_restoration_service.py
@@ -26,7 +26,12 @@ from utils.logger import get_logger
 
 
 class RestorationError(Exception):
-    """Error during OAuth account restoration."""
+    """Error during OAuth account restoration.
+
+    Attributes:
+        email_address: Email of the account that failed to restore
+        cause: The underlying exception that caused the failure
+    """
 
     def __init__(self, email_address: str, cause: Exception):
         """

--- a/services/oauth_account_restoration_service.py
+++ b/services/oauth_account_restoration_service.py
@@ -25,6 +25,22 @@ from typing import List, Dict, Protocol
 from utils.logger import get_logger
 
 
+class RestorationError(Exception):
+    """Error during OAuth account restoration."""
+
+    def __init__(self, email_address: str, cause: Exception):
+        """
+        Initialize restoration error.
+
+        Args:
+            email_address: Email of the account that failed to restore
+            cause: The underlying exception that caused the failure
+        """
+        self.email_address = email_address
+        self.cause = cause
+        super().__init__(f"Database error during restoration for {email_address}")
+
+
 class DatabaseRepositoryProtocol(Protocol):
     """Protocol for database repository interface."""
 
@@ -173,9 +189,7 @@ class OAuthAccountRestorationService:
                         self.logger.exception(
                             f"Database error restoring account {account.email_address}"
                         )
-                        raise Exception(
-                            f"Database error during restoration for {account.email_address}"
-                        ) from e
+                        raise RestorationError(account.email_address, e) from e
 
             self.logger.info(f"Restoration complete. Total accounts restored: {restored_count}")
             return restored_count

--- a/tests/unit/test_gmail_fetcher_oauth_auth_preservation.py
+++ b/tests/unit/test_gmail_fetcher_oauth_auth_preservation.py
@@ -528,22 +528,14 @@ class TestAccountServiceFailureHandledGracefully(unittest.TestCase):
         mock_account_client_class.side_effect = Exception("Database connection failed")
 
         # Act: Should not raise - should handle gracefully
-        try:
-            fetcher = GmailFetcher(
-                email_address="any-user@gmail.com",
-                app_password="test-password",
-                api_token="test-api-token",
-                connection_service=None,
-            )
-            initialization_succeeded = True
-        except Exception as e:
-            initialization_succeeded = False
-
-        # Assert
-        self.assertTrue(
-            initialization_succeeded,
-            "GmailFetcher should initialize successfully even when AccountCategoryClient fails"
+        # If this raises, the test fails automatically
+        _ = GmailFetcher(
+            email_address="any-user@gmail.com",
+            app_password="test-password",
+            api_token="test-api-token",
+            connection_service=None,
         )
+        # If we reach here, initialization succeeded (graceful degradation)
 
     @patch('services.gmail_fetcher_service.AccountCategoryClient')
     @patch('services.gmail_fetcher_service.DomainService')

--- a/tests/unit/test_oauth_account_restoration_service.py
+++ b/tests/unit/test_oauth_account_restoration_service.py
@@ -19,7 +19,7 @@ Implementation should create:
 """
 import unittest
 from typing import Protocol, List, Optional, Dict
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from unittest.mock import MagicMock, Mock, patch, call
 
@@ -52,7 +52,7 @@ class MockEmailAccount:
             auth_method="imap",
             oauth_refresh_token=token,
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
 
     @classmethod
@@ -69,7 +69,7 @@ class MockEmailAccount:
             auth_method="oauth",
             oauth_refresh_token=token,
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
 
     @classmethod
@@ -86,7 +86,7 @@ class MockEmailAccount:
             auth_method="imap",
             oauth_refresh_token=None,
             app_password=password,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
 
 
@@ -647,7 +647,7 @@ class TestEmptyOAuthRefreshTokenNotModified(unittest.TestCase):
             auth_method="imap",
             oauth_refresh_token="",  # Empty string
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
 
         # Act
@@ -673,7 +673,7 @@ class TestEmptyOAuthRefreshTokenNotModified(unittest.TestCase):
             auth_method="imap",
             oauth_refresh_token="",
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
         mock_repository.get_all_accounts.return_value = [empty_token_account]
 
@@ -699,7 +699,7 @@ class TestEmptyOAuthRefreshTokenNotModified(unittest.TestCase):
             auth_method="imap",
             oauth_refresh_token="",
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
         mock_repository.get_all_accounts.return_value = [empty_token_account]
 
@@ -830,7 +830,7 @@ class TestLegacyAccountNotModified(unittest.TestCase):
             auth_method=None,  # Null auth_method
             oauth_refresh_token=None,  # Null oauth_refresh_token
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
 
         # Act
@@ -856,7 +856,7 @@ class TestLegacyAccountNotModified(unittest.TestCase):
             auth_method=None,
             oauth_refresh_token=None,
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
         mock_repository.get_all_accounts.return_value = [legacy_account]
 
@@ -882,7 +882,7 @@ class TestLegacyAccountNotModified(unittest.TestCase):
             auth_method=None,
             oauth_refresh_token=None,
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
         mock_repository.get_all_accounts.return_value = [legacy_account]
 
@@ -1180,7 +1180,7 @@ class TestMixedAccountTypes(unittest.TestCase):
                 auth_method="imap",
                 oauth_refresh_token="",  # Empty
                 app_password=None,
-                updated_at=datetime.utcnow()
+                updated_at=datetime.now(timezone.utc)
             ),
             MockEmailAccount(
                 id=6,
@@ -1188,7 +1188,7 @@ class TestMixedAccountTypes(unittest.TestCase):
                 auth_method=None,  # Null
                 oauth_refresh_token=None,
                 app_password=None,
-                updated_at=datetime.utcnow()
+                updated_at=datetime.now(timezone.utc)
             ),
         ]
         mock_repository.get_all_accounts.return_value = mixed_accounts
@@ -1310,7 +1310,7 @@ class TestCorruptedAccountDetectionEdgeCases(unittest.TestCase):
             auth_method="imap",
             oauth_refresh_token="   ",  # Whitespace only
             app_password=None,
-            updated_at=datetime.utcnow()
+            updated_at=datetime.now(timezone.utc)
         )
 
         # Act
@@ -1347,7 +1347,7 @@ class TestCorruptedAccountDetectionEdgeCases(unittest.TestCase):
                 auth_method=auth_method,
                 oauth_refresh_token="valid-token",
                 app_password=None,
-                updated_at=datetime.utcnow()
+                updated_at=datetime.now(timezone.utc)
             )
 
             # Act


### PR DESCRIPTION
## Summary
- Introduces RestorationError to represent errors during OAuth account restoration
- Replaces a generic Exception with RestorationError in OAuthAccountRestorationService for clearer error handling
- Updates tests to use timezone-aware timestamps (UTC) to avoid subtle datetime issues
- Adjusts Gmail fetcher preservation test to expect graceful degradation when a dependent client fails

## Changes
### Backend
- Added RestorationError(exception) class to encapsulate restoration failures
- Updated OAuthAccountRestorationService to raise RestorationError instead of a bare Exception on database restoration failures

### Tests
- tests/unit/test_gmail_fetcher_oauth_auth_preservation.py
  - Adjusted to rely on graceful degradation instead of catching exceptions during initialization
- tests/unit/test_oauth_account_restoration_service.py
  - Replaced datetime.utcnow() with datetime.now(timezone.utc) across mock accounts to make timestamps timezone-aware

## Test plan
- Run unit tests for OAuth account restoration service
- Run Gmail fetcher related tests
- Verify datetime-related tests use timezone-aware timestamps and pass without issues

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/45aed4b3-6a92-4f91-bcad-89d8086cf784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for account restoration failures with more contextual information to help diagnose issues.

* **Tests**
  * Enhanced test robustness and reliability with improved timezone handling in test cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->