### PR TITLE
Make Gmail OAuth redirect_uri optional; add state fallback

### DIFF
--- a/api_service.py
+++ b/api_service.py
@@ -1500,38 +1500,37 @@ async def oauth_callback(
     Returns:
         OAuthCallbackResponse with success status and granted scopes
     """
-    # Verbose logging for debugging OAuth callback issues (sanitized - no sensitive data)
-    logger.info(f"OAuth callback received - redirect_uri from query: {'provided' if redirect_uri else 'not provided'}")
-    logger.info(f"OAuth callback request body - code: {'present' if request.code else 'missing'}, state: {'present' if request.state else 'missing'}")
+    # Log OAuth callback parameters (sanitized - no sensitive data)
+    logger.info(
+        f"OAuth callback received - "
+        f"redirect_uri: {'provided' if redirect_uri else 'omitted'}, "
+        f"code: {'present' if request.code else 'missing'}, "
+        f"state: {'present' if request.state else 'missing'}"
+    )
 
     verify_api_key(x_api_key)
 
     try:
         # Validate state token from database
-        logger.info("Looking up state token in database")
         state_data = state_repo.get_state(request.state)
         if not state_data:
-            logger.warning("State token not found or expired")
+            logger.warning("OAuth callback failed - state token not found or expired")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid or expired state token. Please restart the OAuth flow."
             )
 
-        logger.info(f"State data retrieved - redirect_uri from state: {'present' if state_data.get('redirect_uri') else 'missing'}")
-
         # Use redirect_uri from state data if not provided in query
         effective_redirect_uri = redirect_uri or state_data.get('redirect_uri')
-        logger.info(f"Effective redirect_uri determined: {'yes' if effective_redirect_uri else 'no'}")
-
         if not effective_redirect_uri:
-            logger.error("No redirect_uri available from query or state data")
+            logger.error("OAuth callback failed - no redirect_uri in query or state")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="No redirect_uri found. Please restart the OAuth flow."
             )
 
         # Exchange authorization code for tokens
-        logger.info("Exchanging authorization code for tokens")
+        logger.info(f"Exchanging authorization code - redirect_uri source: {'query' if redirect_uri else 'state'}")
         token_response = oauth_service.exchange_code_for_tokens(
             code=request.code,
             redirect_uri=effective_redirect_uri,
@@ -2868,9 +2867,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     if "/api/auth/gmail/callback" in str(request.url.path):
         logger.error(f"OAuth callback validation failed - path: {request.url.path}")
         # Log presence of query params without exposing values
-        query_params = dict(request.query_params)
-        sanitized_params = {k: 'present' for k in query_params.keys()}
-        logger.error(f"OAuth callback query params present: {list(sanitized_params.keys())}")
+        logger.error(f"OAuth callback query params present: {list(request.query_params.keys())}")
         # Do not log request body for OAuth callback as it contains sensitive tokens
         logger.error("OAuth callback request body not logged (contains sensitive tokens)")
 

--- a/api_service.py
+++ b/api_service.py
@@ -2872,7 +2872,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
             body = await request.body()
             logger.error(f"OAuth callback request body: {body.decode('utf-8', errors='replace')[:500]}")
         except Exception as e:
-            logger.error(f"Could not read request body: {e}")
+            logger.exception(f"Could not read request body: {e}")
 
     # Return the standard validation error response
     return JSONResponse(


### PR DESCRIPTION
## Summary
- Makes the Gmail OAuth redirect_uri parameter optional in the callback; if omitted, retrieved from the OAuth state.
- Adds validation to require a redirect_uri from either the query or stored state, and returns a 400 if still missing.
- Adds enhanced logging around the callback flow and a dedicated validation error handler for diagnostics.

## Changes

### Backend
- In `api_service.py`, `oauth_callback` signature updated to accept `redirect_uri: Optional[str] = Query(None, description="Same redirect_uri used in authorization request (optional, retrieved from state if not provided)")`.
- Implemented `effective_redirect_uri = redirect_uri or state_data.get('redirect_uri')` and raised a 400 error if still missing with message: "No redirect_uri found. Please restart the OAuth flow.".
- Passed `redirect_uri=effective_redirect_uri` to `oauth_service.exchange_code_for_tokens`.
- Added verbose logging to indicate the source of `redirect_uri` and presence of code/state, and introduced a custom validation error handler to standardize responses and improve diagnostics.
- Updated argument descriptions to reflect optional behavior.

### Documentation
- Updated `docs/oauth.md` to reflect that `redirect_uri` is optional and can be retrieved from state when not provided.
- Added examples for both scenarios:
  - Without `redirect_uri` (recommended, uses stored value).
  - With explicit `redirect_uri` (for backwards compatibility).
- Clarified how the client should call the callback endpoint in both cases.

### Tests
- Updated tests to cover:
  - Callback succeeds with no `redirect_uri` when state contains the redirect_uri.
  - Callback succeeds with explicit `redirect_uri` when provided.
  - Callback returns 400 when no `redirect_uri` is available from either source.
- Client-side calls updated to demonstrate new behavior in docs.

## Test plan
- [x] Callback succeeds with no `redirect_uri` when state contains the redirect_uri
- [x] Callback succeeds with explicit `redirect_uri` when provided
- [x] Callback returns 400 when no `redirect_uri` is available from either source
- [x] Client-side calls updated to demonstrate new behavior in docs

📎 **Task**: https://www.terragonlabs.com/task/76e79c69-e90f-40ca-96ee-fc5629e7953f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth callback now accepts redirect_uri as optional and auto-retrieves it from stored state when omitted.

* **Improvements**
  * Clearer validation and standardized error responses for missing or invalid state (400/422).
  * Enhanced diagnostic logging around callback and token exchange flows.
  * Centralized handling for validation errors to ensure consistent responses.

* **Documentation**
  * Updated OAuth docs and examples to reflect optional redirect_uri and automatic retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->